### PR TITLE
Fix CSR Progress Bars

### DIFF
--- a/database/migrations/2021_11_28_234442_add_start_tier_to_csr.php
+++ b/database/migrations/2021_11_28_234442_add_start_tier_to_csr.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStartTierToCsr extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('csrs', function (Blueprint $table) {
+            $table->mediumInteger('tier_start_csr')
+                ->after('tier')
+                ->unsigned()
+                ->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('csrs', function (Blueprint $table) {
+            $table->dropColumn('tier_start_csr');
+        });
+    }
+}

--- a/resources/views/livewire/competitive-page.blade.php
+++ b/resources/views/livewire/competitive-page.blade.php
@@ -35,8 +35,8 @@
                                 @if (! $playlist->isOnyx())
                                     <progress
                                         class="progress {{ $playlist->getRankPercentColor() }}"
-                                        value="{{ $playlist->csr }}"
-                                        max="{{ $playlist->next_csr }}"
+                                        value="{{ $playlist->current_xp_for_level }}"
+                                        max="{{ $playlist->next_xp_for_level }}"
                                     >%{{ number_format($playlist->next_rank_percent, 2) }}</progress>
                                     <br>
                                     @if ($playlist->hasNextRank())

--- a/tests/Feature/Forms/CompetitivePage/ValidCompetitivePageTest.php
+++ b/tests/Feature/Forms/CompetitivePage/ValidCompetitivePageTest.php
@@ -46,7 +46,7 @@ class ValidCompetitivePageTest extends TestCase
             $livewire->assertSee($playlist->icon, false);
             $livewire->assertSee($playlist->tier_image_url);
             $livewire->assertSee($playlist->rank);
-            $livewire->assertSee($playlist->csr);
+            $livewire->assertSee(number_format($playlist->csr));
         }
     }
 }


### PR DESCRIPTION
Turns out taking current / total, makes each level closer to 99% because if you are at 1250 / 1300. That is pretty much 99%, but the 50 SR climb is still real. 

(old)
![bugged](https://user-images.githubusercontent.com/611784/143791624-4b4619ea-d106-4266-9444-0b44e5e4251f.png)

(new)
![fixed](https://user-images.githubusercontent.com/611784/143791627-787fc84a-9f74-4316-9b00-dbd7f8ec90b3.png)
