### PR TITLE
fix: handle edge case with negative shots missed

### DIFF
--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -72,6 +72,11 @@ class GamePlayer extends Model implements HasHaloDotApi
         $this->attributes['outcome'] = $outcome->value;
     }
 
+    public function setShotsMissedAttribute(int $value): void
+    {
+        $this->attributes['shots_missed'] = $value < 0 ? 0 : $value;
+    }
+
     public static function fromHaloDotApi(array $payload): ?self
     {
         /** @var Player $player */


### PR DESCRIPTION
Somehow SNlPEDRONE has 4 shots hit, 3 shots made in a game. This results in the API returning -1 as the missed property, which failed db constraints.

```
[2021-11-29 01:33:25] production.ERROR: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'shots_missed' at row 1 (SQL: insert into `game_players` (`player_id`, `game_id`, `rank`, `outcome`, `kd`, `kda`, `score`, `kills`, `deaths`, `assists`, `betrayals`, `suicides`, `vehicle_destroys`, `vehicle_hijacks`, `medal_count`, `damage_taken`, `damage_dealt`, `shots_fired`, `shots_landed`, `shots_missed`, `accuracy`, `rounds_won`, `rounds_lost`, `rounds_tied`, `kills_melee`, `kills_grenade`, `kills_headshot`, `kills_power`, `assists_emp`, `assists_driver`, `assists_callout`) values (44, 5564, 6, 2, 0.16666666666667, -10, 200, 2, 12, 0, 0, 0, 0, 0, 1, 2840, 444, 3, 4, -1, 133.33, 0, 2, 0, 0, 0, 1, 1, 0, 0, 0))  
```

Unsure if this is a bug in 343 or HaloDotAPI.