### PR TITLE
refactor: force update report if no "queue"

### DIFF
--- a/resources/views/livewire/game-page.blade.php
+++ b/resources/views/livewire/game-page.blade.php
@@ -5,7 +5,7 @@
     <div class="column">
         @include('partials.game.game-card')
         @include('partials.game.team-breakdown')
-        @if ($game->players->count() <= 1)
+        @if (empty($game->queue))
             <livewire:update-game-panel :game="$game" />
         @endif
     </div>

--- a/tests/Feature/Pages/GamePageTest.php
+++ b/tests/Feature/Pages/GamePageTest.php
@@ -16,6 +16,9 @@ class GamePageTest extends TestCase
         Http::fake();
 
         $game = Game::factory()->createOne();
+        Game::query()
+            ->where('id', $game->id)
+            ->update(['queue' => null]);
 
         // Act
         $response = $this->get('/game/' . $game->uuid);


### PR DESCRIPTION
Corrects pages where a few known players are in game, but not rest.