### PR TITLE
Refactor Playlists

### DIFF
--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -38,6 +38,15 @@ class Playlist extends Model implements HasHaloDotApi
         'input' => Input::class,
     ];
 
+    public function getNameAttribute(string $value): string
+    {
+        if ($value === 'Unknown') {
+            return 'Featured';
+        }
+
+        return $value;
+    }
+
     public static function fromHaloDotApi(array $payload): ?self
     {
         $playlistId = Arr::get($payload, 'asset.id');

--- a/app/Models/Traits/HasPlaylist.php
+++ b/app/Models/Traits/HasPlaylist.php
@@ -14,7 +14,10 @@ trait HasPlaylist
 {
     public function getTitleAttribute(): string
     {
-        return $this->queue->description ?? '';
+        if ($this->name === 'Unknown') {
+            return 'Featured';
+        }
+        return $this->name ?? $this->queue->description ?? '';
     }
 
     public function getIconAttribute(): ? string

--- a/app/Models/Traits/HasPlaylist.php
+++ b/app/Models/Traits/HasPlaylist.php
@@ -14,10 +14,7 @@ trait HasPlaylist
 {
     public function getTitleAttribute(): string
     {
-        if ($this->name === 'Unknown') {
-            return 'Featured';
-        }
-        return $this->name ?? $this->queue->description ?? '';
+        return $this->queue->description ?? '';
     }
 
     public function getIconAttribute(): ? string

--- a/app/Services/Autocode/ApiClient.php
+++ b/app/Services/Autocode/ApiClient.php
@@ -58,22 +58,23 @@ class ApiClient implements InfiniteInterface
 
     public function matches(Player $player, bool $forceUpdate = false): Collection
     {
-        $count = 25;
+        $perPage = 25;
+        $count = $perPage;
         $offset = 0;
-        $total = PHP_INT_MAX;
 
-        while (($count + $offset) < $total) {
-            $response = $this->pendingRequest->get('stats/matches/list', [
+        while ($count !== 0) {
+            $response = $this->pendingRequest->post('stats/matches/list', [
                 'gamertag' => $player->gamertag,
-                'mode' => Mode::MATCHMADE,
-                'count' => $count,
-                'offset' => $offset
+                'limit' => [
+                    'count' => $perPage,
+                    'offset' => $offset + $perPage
+                ]
             ]);
 
             if ($response->throw()->successful()) {
                 $data = $response->json();
-                $offset = (int)Arr::get($data, 'paging.offset', 0) + $count;
-                $total = (int)Arr::get($data, 'paging.total', 0);
+                $count = (int)Arr::get($data, 'paging.count', 0);
+                $offset += $count;
 
                 foreach (Arr::get($data, 'data') as $gameData) {
                     $game = Game::fromHaloDotApi((array)$gameData);

--- a/database/migrations/2021_12_15_115237_add_playlist_id_to_games.php
+++ b/database/migrations/2021_12_15_115237_add_playlist_id_to_games.php
@@ -13,6 +13,7 @@ class AddPlaylistIdToGames extends Migration
         Schema::table('games', function (Blueprint $table) {
             $table->foreignIdFor(Playlist::class)
                 ->after('map_id')
+                ->nullable(true)
                 ->constrained();
         });
     }

--- a/database/migrations/2021_12_15_115237_add_playlist_id_to_games.php
+++ b/database/migrations/2021_12_15_115237_add_playlist_id_to_games.php
@@ -12,7 +12,6 @@ class AddPlaylistIdToGames extends Migration
     {
         Schema::table('games', function (Blueprint $table) {
             $table->foreignIdFor(Playlist::class)
-                ->nullable(true)
                 ->after('map_id')
                 ->constrained();
         });

--- a/resources/views/livewire/game-history-table.blade.php
+++ b/resources/views/livewire/game-history-table.blade.php
@@ -5,7 +5,7 @@
     <table class="table is-striped is-narrow is-hoverable is-fullwidth">
         <thead>
             <tr>
-                <th>Mode</th>
+                <th>Playlist</th>
                 <th>Map</th>
                 <th>Gametype</th>
                 <th>Outcome</th>

--- a/resources/views/livewire/game-history-table.blade.php
+++ b/resources/views/livewire/game-history-table.blade.php
@@ -24,7 +24,7 @@
                 <tr>
                     <td>
                         <a href="{{ route('game', [$game]) }}">
-                            {{ $game->playlist->title }}
+                            {{ $game->playlist->name }}
                         </a>
                         @if ($game->playlist->is_ranked)
                             <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>

--- a/resources/views/livewire/game-history-table.blade.php
+++ b/resources/views/livewire/game-history-table.blade.php
@@ -24,9 +24,9 @@
                 <tr>
                     <td>
                         <a href="{{ route('game', [$game]) }}">
-                            {{ $game->experience->description }}
+                            {{ $game->playlist->title }}
                         </a>
-                        @if ($game->is_ranked)
+                        @if ($game->playlist->is_ranked)
                             <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
                         @endif
                     </td>

--- a/resources/views/partials/game/game-card.blade.php
+++ b/resources/views/partials/game/game-card.blade.php
@@ -20,7 +20,7 @@
             </div>
         </div>
         <div class="content">
-            {{ $game->playlist->name }}
+            {{ $game->playlist->title }}
             @if ($game->playlist->is_ranked)
                 <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
             @endif

--- a/resources/views/partials/game/game-card.blade.php
+++ b/resources/views/partials/game/game-card.blade.php
@@ -20,16 +20,9 @@
             </div>
         </div>
         <div class="content">
-            @if ($game->playlist)
-                {{ $game->playlist->name }}
-                @if ($game->playlist->is_ranked)
-                    <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
-                @endif
-            @else
-                {{ $game->experience->description }}
-                @if ($game->is_ranked)
-                    <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
-                @endif
+            {{ $game->playlist->name }}
+            @if ($game->playlist->is_ranked)
+                <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
             @endif
             <br />
             <time datetime="{{ $game->occurred_at->toIso8601ZuluString() }}">

--- a/resources/views/partials/game/game-card.blade.php
+++ b/resources/views/partials/game/game-card.blade.php
@@ -20,7 +20,7 @@
             </div>
         </div>
         <div class="content">
-            {{ $game->playlist->title }}
+            {{ $game->playlist->name }}
             @if ($game->playlist->is_ranked)
                 <abbr title="Ranked"><i class="fa fa-crosshairs"></i></abbr>
             @endif

--- a/tests/Feature/Console/PullHaloDataTest.php
+++ b/tests/Feature/Console/PullHaloDataTest.php
@@ -30,11 +30,13 @@ class PullHaloDataTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([

--- a/tests/Feature/Forms/GameHistoryTable/ValidGameHistoryTableTest.php
+++ b/tests/Feature/Forms/GameHistoryTable/ValidGameHistoryTableTest.php
@@ -40,7 +40,7 @@ class ValidGameHistoryTableTest extends TestCase
             'player' => $player
         ])
             ->assertViewHas('games')
-            ->assertSee($game->experience->description)
+            ->assertSee($game->playlist->title)
             ->assertSee($game->map->name)
             ->assertSee($game->category->name)
             ->assertSee($game->personal->outcome->description)

--- a/tests/Feature/Forms/GameHistoryTable/ValidGameHistoryTableTest.php
+++ b/tests/Feature/Forms/GameHistoryTable/ValidGameHistoryTableTest.php
@@ -40,7 +40,7 @@ class ValidGameHistoryTableTest extends TestCase
             'player' => $player
         ])
             ->assertViewHas('games')
-            ->assertSee($game->playlist->title)
+            ->assertSee($game->playlist->name)
             ->assertSee($game->map->name)
             ->assertSee($game->category->name)
             ->assertSee($game->personal->outcome->description)

--- a/tests/Feature/Forms/UpdatePlayerPanel/InvalidPlayerUpdateTest.php
+++ b/tests/Feature/Forms/UpdatePlayerPanel/InvalidPlayerUpdateTest.php
@@ -53,11 +53,13 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->error429();
 
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_TOO_MANY_REQUESTS);
 
         $player = Player::factory()->createOne([
@@ -80,6 +82,7 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Arr::set($mockMatchesResponse, 'data.0.experience', 'unknown-gametype');
@@ -87,6 +90,7 @@ class InvalidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -109,6 +113,7 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Arr::set($mockMatchesResponse, 'data.0.details.playlist.properties.queue', 'unknown-queue');
@@ -116,6 +121,7 @@ class InvalidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -138,6 +144,7 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Arr::set($mockMatchesResponse, 'data.0.details.playlist.properties.input', 'unknown-input');
@@ -145,6 +152,7 @@ class InvalidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -167,6 +175,7 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Arr::set($mockMatchesResponse, 'data.0.player.outcome', 'crashed');
@@ -174,6 +183,7 @@ class InvalidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -196,6 +206,7 @@ class InvalidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Arr::set($mockCsrResponse, 'data.0.queue', 'closed');
@@ -203,6 +214,7 @@ class InvalidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([

--- a/tests/Feature/Forms/UpdatePlayerPanel/ValidPlayerUpdateTest.php
+++ b/tests/Feature/Forms/UpdatePlayerPanel/ValidPlayerUpdateTest.php
@@ -35,6 +35,7 @@ class ValidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         // Set values into responses that "fake" a private account.
@@ -44,6 +45,7 @@ class ValidPlayerUpdateTest extends TestCase
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -71,6 +73,7 @@ class ValidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
         $mockXuidResponse = (new MockXuidService())->success($gamertag);
 
@@ -78,6 +81,7 @@ class ValidPlayerUpdateTest extends TestCase
             ->push($mockXuidResponse, Response::HTTP_OK)
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -106,11 +110,13 @@ class ValidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([
@@ -220,11 +226,13 @@ class ValidPlayerUpdateTest extends TestCase
         $gamertag = $this->faker->word . $this->faker->numerify;
         $mockCsrResponse = (new MockCsrAllService())->success($gamertag);
         $mockMatchesResponse = (new MockMatchesService())->success($gamertag);
+        $mockEmptyMatchesResponse = (new MockMatchesService())->empty($gamertag);
         $mockServiceResponse = (new MockServiceRecordService())->success($gamertag);
 
         Http::fakeSequence()
             ->push($mockCsrResponse, Response::HTTP_OK)
             ->push($mockMatchesResponse, Response::HTTP_OK)
+            ->push($mockEmptyMatchesResponse, Response::HTTP_OK)
             ->push($mockServiceResponse, Response::HTTP_OK);
 
         $player = Player::factory()->createOne([

--- a/tests/Feature/Pages/GamePageTest.php
+++ b/tests/Feature/Pages/GamePageTest.php
@@ -52,10 +52,12 @@ class GamePageTest extends TestCase
         // Arrange
         Http::fake();
 
-        $game = Game::factory()->createOne([
-            'version' => config('services.autocode.version'),
-            'was_pulled' => true
-        ]);
+        $game = Game::factory()
+            ->forPlaylist(['name' => 'Unknown'])
+            ->createOne([
+                'version' => config('services.autocode.version'),
+                'was_pulled' => true
+            ]);
 
         // Act
         $response = $this->get('/game/' . $game->uuid);

--- a/tests/Mocks/Matches/MockMatchesService.php
+++ b/tests/Mocks/Matches/MockMatchesService.php
@@ -10,7 +10,7 @@ class MockMatchesService extends BaseMock
 {
     use HasErrorFunctions;
 
-    public function success(string $gamertag, int $count = 2, int $offset = 0, ?int $total = 2): array
+    public function success(string $gamertag, int $count = 2, int $offset = 0): array
     {
         return [
             'data' => [
@@ -233,11 +233,26 @@ class MockMatchesService extends BaseMock
                     ]
                 ]
             ],
-            'count' => 25,
+            'count' => $count,
             'paging' => [
                 'count' => $count,
-                'offset' => $offset,
-                'total' => $total,
+                'offset' => $offset
+            ],
+            'additional' => [
+                'gamertag' => $gamertag,
+                'mode' => 'matchmade'
+            ]
+        ];
+    }
+
+    public function empty(string $gamertag, int $offset = 0): array
+    {
+        return [
+            'data' => [],
+            'count' => 0,
+            'paging' => [
+                'count' => 0,
+                'offset' => $offset
             ],
             'additional' => [
                 'gamertag' => $gamertag,


### PR DESCRIPTION
The API removed `$total` from history, which is what Leaf used to know when games were missing. This removal broke nearly everything, so had to refactor the entire pulling of match history.