### PR TITLE
fix: allow auto-refresh with medal information on overview

### DIFF
--- a/resources/views/livewire/overview-page.blade.php
+++ b/resources/views/livewire/overview-page.blade.php
@@ -23,9 +23,11 @@
             </div>
         </article>
     @else
-        @include('partials.player.stats')
-        @if ($serviceRecord->medals)
-            @include('partials.player.medal-groups')
-        @endif
+        <div>
+            @include('partials.player.stats')
+            @if ($serviceRecord->medals)
+                @include('partials.player.medal-groups')
+            @endif
+        </div>
     @endif
 @endif


### PR DESCRIPTION
This fixes an issue when we emit a Livewire refresh and there was no main div, so it could not refresh the 2nd div (medals) until a manual refresh.