### PR TITLE
fix: use block vs explicit br tag

### DIFF
--- a/resources/views/partials/player/medals.blade.php
+++ b/resources/views/partials/player/medals.blade.php
@@ -13,8 +13,9 @@
                             {{ $medal->name }}
                         </strong>
                     </span>
-                    <br>
-                    {{ $medal->count }}
+                    <span class="is-clipped" style="display: block;">
+                        {{ $medal->count }}
+                    </span>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This prevents longer medals from having dual newlines due to long medal name.