### PR TITLE
fix: don't let match history timeout after 60s

### DIFF
--- a/app/Jobs/PullMatchHistory.php
+++ b/app/Jobs/PullMatchHistory.php
@@ -16,6 +16,9 @@ class PullMatchHistory implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 2;
+    public int $timeout = 360;
+
     private Player $player;
 
     public function __construct(Player $player)


### PR DESCRIPTION
fixes: #164 