### PR TITLE
fix: bump to 180s timeout for HaloDotAPI

### DIFF
--- a/app/Services/Autocode/ApiClient.php
+++ b/app/Services/Autocode/ApiClient.php
@@ -24,6 +24,7 @@ class ApiClient implements InfiniteInterface
     {
         $this->pendingRequest = Http::asJson()
             ->baseUrl($config['domain'] . '/infinite@'. $config['version'])
+            ->timeout(180)
             ->withToken($config['key']);
     }
 


### PR DESCRIPTION
ServiceRecord is taking awhile to parse.