### PR TITLE
fix: groupBy implicit keys by groupBy key

### DIFF
--- a/app/Http/Livewire/GamePage.php
+++ b/app/Http/Livewire/GamePage.php
@@ -23,7 +23,9 @@ class GamePage extends Component
 
     public function render(): View
     {
-        $groupedPlayers = $this->game->players->groupBy('game_team_id');
+        $this->game->load('teams.players');
+
+        $groupedPlayers = $this->game->players->groupBy('team.internal_team_id');
 
         if (! $this->game->outdated) {
             $this->game->players->each(function (GamePlayer $gamePlayer) {


### PR DESCRIPTION
Not sure when this happened. Noticed a donation that mentioned it broke.

My gut is that a Laravel upgrade changed how `groupBy` works and it now implicitly keys by the `groupBy` key, when in the past we used the internal_team_id, which swapped between 0/1. Since those are the same keys that were implicitly used as indexes in PHP go 0,1,2. We never noticed.

This needs a better investigation, but grouping by the internal key is working for a quick fix.

refs: #256 