### PR TITLE
Merged Service Records (S1 + S2)

### DIFF
--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -12,7 +12,6 @@ use App\Jobs\PullServiceRecord;
 use App\Models\Contracts\HasHaloDotApi;
 use App\Models\Pivots\MatchupPlayer;
 use App\Models\Pivots\PersonalResult;
-use App\Services\Autocode\Enums\Filter;
 use App\Services\Autocode\Enums\Mode;
 use App\Services\Autocode\InfiniteInterface;
 use App\Services\XboxApi\XboxInterface;

--- a/app/Models/ServiceRecord.php
+++ b/app/Models/ServiceRecord.php
@@ -222,6 +222,12 @@ class ServiceRecord extends Model implements HasHaloDotApi
 
     public function scopeOfSeason(Builder $query, int $season): Builder
     {
+        // If we are using -1 - that is all seasons combined. Swap to VIEW
+        // Which has the merged results of that mode.
+        if ($season === -1) {
+            return $query->from('merged_service_records', 'service_records');
+        }
+
         return $query->where('season_number', $season);
     }
 }

--- a/database/migrations/2022_05_03_101000_add_database_view.php
+++ b/database/migrations/2022_05_03_101000_add_database_view.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(
+            <<<SQL
+                CREATE VIEW `merged_service_records` AS
+                    SELECT
+                           player_id,
+                           mode,
+                           AVG(kd) AS kd,
+                           AVG(kda) AS kda,
+                           CAST(SUM(total_score) AS UNSIGNED INTEGER) AS total_score,
+                           SUM(total_matches) AS total_matches,
+                           SUM(matches_won) AS matches_won,
+                           SUM(matches_lost) AS matches_lost,
+                           SUM(matches_tied) AS matches_tied,
+                           SUM(matches_left) AS matches_left,
+                           SUM(total_seconds_played) AS total_seconds_played,
+                           SUM(kills) AS kills,
+                           SUM(deaths) AS deaths,
+                           SUM(assists) AS assists,
+                           SUM(betrayals) AS betrayals,
+                           SUM(suicides) AS suicides,
+                           SUM(medal_count) AS medal_count,
+                           SUM(damage_taken) AS damage_taken,
+                           SUM(damage_dealt) AS damage_dealt,
+                           SUM(shots_fired) AS shots_fired,
+                           SUM(shots_landed) AS shots_landed,
+                           SUM(shots_missed) AS shots_missed,
+                           AVG(accuracy) AS accuracy,
+                           SUM(kills_melee) AS kills_melee,
+                           SUM(kills_grenade) AS kills_grenade,
+                           SUM(kills_headshot) AS kills_headshot,
+                           SUM(kills_power) AS kills_power,
+                           GROUP_CONCAT(medals SEPARATOR '|') AS medals
+                    FROM service_records
+                    GROUP BY player_id, mode;
+            SQL
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement(
+            <<<SQL
+                DROP VIEW IF EXISTS `merged_service_records`;
+            SQL
+        );
+    }
+};

--- a/resources/views/livewire/overview-page.blade.php
+++ b/resources/views/livewire/overview-page.blade.php
@@ -22,7 +22,7 @@
     @else
         <div>
             @include('partials.player.stats')
-            @if ($serviceRecord->medals)
+            @if ($serviceRecord->medal_count > 0)
                 @include('partials.player.medal-groups')
             @endif
         </div>

--- a/resources/views/livewire/player-toggle-panel.blade.php
+++ b/resources/views/livewire/player-toggle-panel.blade.php
@@ -7,6 +7,7 @@
             <select wire:model="season" wire:change="onSeasonChange">
                 <option value="1">Season 1</option>
                 <option value="2">Season 2</option>
+                <option value="-1">All Seasons</option>
             </select>
         </div>
     </div>


### PR DESCRIPTION
The main issue is the `medals` column now. Its JSON and no good way to merge that and search it. Exploring:

 * Using `JSON_TABLE()` to extract to relational and remove the JSON nature to easily sum
 * Leverage some form of `JSON_*` to merge properly
 * Use a CTE to crawl each entry and build up a merge result.

---

The problem is like this. The `medals` column is a JSON column on `service_records`, its also as well like that on `game_players` for the medals of a specific match.

So imagine below the overall medal stats of season 1 vs 2.
```
{"1512363953":359,"3334154676":142} - Season 1
{"1512363953":1,"3334154676":3} - Season 2
```

How do you get in pure database.
```
{"1512363953":360,"3334154676":145} - All seasons
```

I could use PHP easily, but then I break leaderboards since I need to be able to sort by the merged to find top 5.