### PR TITLE
feat: CSS Updates

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -14,6 +14,7 @@ html {
 
 body {
     min-height: 100%;
+    padding: 0 1rem;
 }
 
 td {

--- a/resources/views/partials/game/game-card.blade.php
+++ b/resources/views/partials/game/game-card.blade.php
@@ -13,7 +13,7 @@
                 </span>
             </div>
         @endif
-        <figure class="image is-4by3">
+        <figure class="image">
             <img src="{{ $game->map->image }}" alt="{{ $game->map->name }}">
         </figure>
     </div>

--- a/resources/views/partials/player/csr-card-row.blade.php
+++ b/resources/views/partials/player/csr-card-row.blade.php
@@ -7,7 +7,7 @@
             </span>
         </div>
         <div class="card-image has-background-light">
-            <figure class="image is-5by4">
+            <figure class="image">
                 <img src="{{ $playlist->toCsrObject()->url() }}" alt="{{ $playlist->rank }}">
             </figure>
         </div>


### PR DESCRIPTION
- Respect images ratio (CSR + Map)
- Added a default padding on body (better render on mobile)

| CSR      | Profile | Match  |
| ----------- | -----------  | ----------- |
| ![Capture d’écran 2022-06-09 à 21 02 41](https://user-images.githubusercontent.com/1816892/172926528-375e3624-268d-42a4-968f-5b23569b35e1.png)      | ![Capture d’écran 2022-06-09 à 21 11 17](https://user-images.githubusercontent.com/1816892/172926573-e1c3980e-c467-4575-b00d-39b349a1e880.png)       | ![Capture d’écran 2022-06-09 à 21 11 42](https://user-images.githubusercontent.com/1816892/172926603-458095a2-56a8-4ed7-8d26-c32e4c17d6c5.png)       |



