### PR TITLE
test: remove phpunit deprecations

### DIFF
--- a/tests/Feature/Console/PullChampionshipTest.php
+++ b/tests/Feature/Console/PullChampionshipTest.php
@@ -119,7 +119,7 @@ class PullChampionshipTest extends TestCase
             ->assertExitCode(CommandAlias::FAILURE);
     }
 
-    public function championshipTypeDataProvider(): array
+    public static function championshipTypeDataProvider(): array
     {
         return [
             [

--- a/tests/Feature/Forms/AddGamer/InvalidGamerFormTest.php
+++ b/tests/Feature/Forms/AddGamer/InvalidGamerFormTest.php
@@ -60,7 +60,7 @@ class InvalidGamerFormTest extends TestCase
             ->assertRedirect('/player/'.$gamertag);
     }
 
-    public function invalidApiDataProvider(): array
+    public static function invalidApiDataProvider(): array
     {
         return [
             401 => [
@@ -86,7 +86,7 @@ class InvalidGamerFormTest extends TestCase
         ];
     }
 
-    public function invalidTextDataProvider(): array
+    public static function invalidTextDataProvider(): array
     {
         return [
             'empty' => [

--- a/tests/Feature/Forms/OverviewPage/ValidOverviewPageTest.php
+++ b/tests/Feature/Forms/OverviewPage/ValidOverviewPageTest.php
@@ -65,7 +65,7 @@ class ValidOverviewPageTest extends TestCase
             ->assertDontSee('Other');
     }
 
-    public function validAttributesDataProvider(): array
+    public static function validAttributesDataProvider(): array
     {
         return [
             'positive kd' => [

--- a/tests/Feature/Pages/HcsBracketPageTest.php
+++ b/tests/Feature/Pages/HcsBracketPageTest.php
@@ -56,7 +56,7 @@ class HcsBracketPageTest extends TestCase
         $response->assertSeeLivewire('championship-bracket');
     }
 
-    public function bracketDataProvider(): array
+    public static function bracketDataProvider(): array
     {
         return [
             [

--- a/tests/Feature/Pages/HcsMatchupPageTest.php
+++ b/tests/Feature/Pages/HcsMatchupPageTest.php
@@ -113,7 +113,7 @@ class HcsMatchupPageTest extends TestCase
         $response->assertSeeLivewire('championship-matchup');
     }
 
-    public function groupDataProvider(): array
+    public static function groupDataProvider(): array
     {
         return [
             [

--- a/tests/Feature/Pages/PlayerPageTest.php
+++ b/tests/Feature/Pages/PlayerPageTest.php
@@ -201,7 +201,7 @@ class PlayerPageTest extends TestCase
         $response->assertSeeLivewire('update-player-panel');
     }
 
-    public function gamertagDataProvider(): array
+    public static function gamertagDataProvider(): array
     {
         return [
             'spaces' => [

--- a/tests/Traits/HasAnalyticDataProvider.php
+++ b/tests/Traits/HasAnalyticDataProvider.php
@@ -22,7 +22,7 @@ use App\Support\Analytics\Stats\MostTimePlayedServiceRecord;
 
 trait HasAnalyticDataProvider
 {
-    public function analyticDataProvider(): array
+    public static function analyticDataProvider(): array
     {
         return [
             [

--- a/tests/Unit/Models/CsrModelTest.php
+++ b/tests/Unit/Models/CsrModelTest.php
@@ -47,7 +47,7 @@ class CsrModelTest extends TestCase
         $this->assertEquals($expected, $csr->next_rank);
     }
 
-    public function nextRankDataProvider(): array
+    public static function nextRankDataProvider(): array
     {
         return [
             'diamond' => [
@@ -85,7 +85,7 @@ class CsrModelTest extends TestCase
         ];
     }
 
-    public function rankDataProvider(): array
+    public static function rankDataProvider(): array
     {
         return [
             'diamond' => [

--- a/tests/Unit/Models/GameTeamModelTest.php
+++ b/tests/Unit/Models/GameTeamModelTest.php
@@ -24,7 +24,7 @@ class GameTeamModelTest extends TestCase
         $this->assertEquals('has-tooltip-'.$expected, $gameTeam->tooltip_color);
     }
 
-    public function teamColorDataProvider(): array
+    public static function teamColorDataProvider(): array
     {
         return [
             [

--- a/tests/Unit/Support/CsrHelperTest.php
+++ b/tests/Unit/Support/CsrHelperTest.php
@@ -52,7 +52,7 @@ class CsrHelperTest extends TestCase
         );
     }
 
-    public function unrankedCsrDataProvider(): array
+    public static function unrankedCsrDataProvider(): array
     {
         return [
             'unranked 0' => [
@@ -74,7 +74,7 @@ class CsrHelperTest extends TestCase
         ];
     }
 
-    public function csrDataProvider(): array
+    public static function csrDataProvider(): array
     {
         return [
             'bronze 1' => [


### PR DESCRIPTION
This was odd, missed it during L10 upgrade because I only ran `php artisan test` which hides these deprecations. Reported a bug upstream to Laravel and might attempt a fix when done with HCS upgrades.

https://github.com/laravel/framework/issues/46168