### PR TITLE
fix: remove cron monitoring

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,17 +22,13 @@ class Kernel extends ConsoleKernel
 
     protected function schedule(Schedule $schedule)
     {
-        // @phpstan-ignore-next-line
         $schedule->command(PullMetadata::class)
             ->withoutOverlapping()
-            ->twiceDaily()
-            ->sentryMonitor(config('services.sentry.crons.pull-metdata'));
+            ->twiceDaily();
 
-        // @phpstan-ignore-next-line
         $schedule->command(RefreshAnalytics::class)
             ->withoutOverlapping()
-            ->daily()
-            ->sentryMonitor(config('services.sentry.crons.refresh-analytics'));
+            ->daily();
 
         $schedule->command('horizon:snapshot')
             ->everyFiveMinutes();


### PR DESCRIPTION
This didn't appear to work.

Looks like recently merged by @cleptric in https://github.com/getsentry/sentry-laravel/pull/659 and can't quite spot my mistake. Macros must not be loading somehow.

https://leaf-hi.sentry.io/share/issue/0971d4b094e54beca3fe5a78b3a1581d/

---

Will revisit in weekend.