### PR TITLE
fix: remove "thumbnail_url" from playlist

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -21,10 +21,6 @@ class GameController extends Controller
             $game->map->thumbnail_url,
         ];
 
-        if ($game->playlist) {
-            $images[] = $game->playlist->thumbnail_url;
-        }
-
         SEOTools::setTitle($game->name);
         SEOTools::addImages($images);
         SEOTools::setDescription($game->description);

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Arr;
  * @property int $id
  * @property string $uuid
  * @property string $name
- * @property string $thumbnail_url
  * @property bool $is_ranked
  * @property Queue|null $queue
  * @property Input|null $input
@@ -68,7 +67,6 @@ class Playlist extends Model implements HasHaloDotApi
             ]);
 
         $playlist->name = Arr::get($payload, 'name');
-        $playlist->thumbnail_url = Arr::get($payload, 'asset.thumbnail_url');
         $playlist->is_ranked = Arr::get($payload, 'properties.ranked');
         $playlist->queue = Arr::get($payload, 'properties.queue');
         $playlist->input = Arr::get($payload, 'properties.input');

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -19,7 +19,6 @@ class PlaylistFactory extends Factory
         return [
             'uuid' => $this->faker->unique()->uuid,
             'name' => $this->faker->word,
-            'thumbnail_url' => $this->faker->imageUrl,
             'is_ranked' => $this->faker->boolean,
             'queue' => Queue::getRandomValue(),
             'input' => Input::getRandomValue(),

--- a/database/migrations/2023_03_25_171951_drop_thumbnail_from_playlist.php
+++ b/database/migrations/2023_03_25_171951_drop_thumbnail_from_playlist.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('thumbnail_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->string('thumbnail_url');
+        });
+    }
+};


### PR DESCRIPTION
This is only used in SEO and the URL shifts between seasons. So we are hammering updates to a column we don't use.