### PR TITLE
fix: prevent "is_ranked" being marked as dirty

### DIFF
--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -36,7 +36,7 @@ class Playlist extends Model implements HasHaloDotApi
     public $casts = [
         'queue' => Queue::class,
         'input' => Input::class,
-        'is_ranked' => 'bool'
+        'is_ranked' => 'bool',
     ];
 
     public function getNameAttribute(string $value): string

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -36,6 +36,7 @@ class Playlist extends Model implements HasHaloDotApi
     public $casts = [
         'queue' => Queue::class,
         'input' => Input::class,
+        'is_ranked' => 'bool'
     ];
 
     public function getNameAttribute(string $value): string


### PR DESCRIPTION
Everytime we save information it finds `is_ranked` is 0/1, but we compare to true/false and thus its marked as dirty. This means we have playlists saving non-stop and leading to locks/etc.

Refs: #563 