### PR TITLE
fix: default a game to non-ffa

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -204,7 +204,12 @@ class Game extends Model implements HasHaloDotApi
         if (isset($playlist)) {
             $game->playlist()->associate($playlist);
         }
-        $game->is_ffa = count(Arr::get($payload, 'teams', [])) === 0;
+
+        $game->is_ffa = false;
+        if (Arr::has($payload, 'teams')) {
+            $game->is_ffa = count(Arr::get($payload, 'teams', [])) === 0;
+        }
+
         $game->is_lan ??= $mode && $mode->is(Mode::LAN());
         $game->experience = Arr::get($payload, 'properties.experience');
         $game->occurred_at = Arr::get($payload, 'started_at');


### PR DESCRIPTION
Default a game to non-ffa, because the game player endpoint no longer returns the team. So we don't know until team of match pull.