### PR TITLE
fix: leaderboards should look for missing season_key

### DIFF
--- a/app/Support/Analytics/Stats/BestAccuracyServiceRecord.php
+++ b/app/Support/Analytics/Stats/BestAccuracyServiceRecord.php
@@ -51,7 +51,7 @@ class BestAccuracyServiceRecord extends BasePlayerStat implements AnalyticInterf
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->where('total_matches', '>=', 1000)
             ->orderByDesc($this->property())
             ->limit($limit)

--- a/app/Support/Analytics/Stats/BestKDAServiceRecord.php
+++ b/app/Support/Analytics/Stats/BestKDAServiceRecord.php
@@ -51,7 +51,7 @@ class BestKDAServiceRecord extends BasePlayerStat implements AnalyticInterface
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->where('total_matches', '>=', 1000)
             ->orderByDesc($this->property())
             ->limit($limit)

--- a/app/Support/Analytics/Stats/BestKDServiceRecord.php
+++ b/app/Support/Analytics/Stats/BestKDServiceRecord.php
@@ -51,7 +51,7 @@ class BestKDServiceRecord extends BasePlayerStat implements AnalyticInterface
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->where('total_matches', '>=', 1000)
             ->orderByDesc($this->property())
             ->limit($limit)

--- a/app/Support/Analytics/Stats/MostBetrayalsServiceRecord.php
+++ b/app/Support/Analytics/Stats/MostBetrayalsServiceRecord.php
@@ -51,7 +51,7 @@ class MostBetrayalsServiceRecord extends BasePlayerStat implements AnalyticInter
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostKillsServiceRecord.php
+++ b/app/Support/Analytics/Stats/MostKillsServiceRecord.php
@@ -51,7 +51,7 @@ class MostKillsServiceRecord extends BasePlayerStat implements AnalyticInterface
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostMedalsServiceRecord.php
+++ b/app/Support/Analytics/Stats/MostMedalsServiceRecord.php
@@ -51,7 +51,7 @@ class MostMedalsServiceRecord extends BasePlayerStat implements AnalyticInterfac
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostTimePlayedServiceRecord.php
+++ b/app/Support/Analytics/Stats/MostTimePlayedServiceRecord.php
@@ -51,7 +51,7 @@ class MostTimePlayedServiceRecord extends BasePlayerStat implements AnalyticInte
             ->leftJoin('players', 'players.id', '=', 'service_records.player_id')
             ->where('is_cheater', false)
             ->where('mode', Mode::MATCHMADE_PVP)
-            ->whereNull('season_number')
+            ->whereNull('season_key')
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/tests/Feature/Jobs/ProcessAnalyticTest.php
+++ b/tests/Feature/Jobs/ProcessAnalyticTest.php
@@ -28,7 +28,7 @@ class ProcessAnalyticTest extends TestCase
         Http::fake()->preventStrayRequests();
         ServiceRecord::factory()->createOne([
             'mode' => Mode::MATCHMADE_PVP,
-            'season_number' => null,
+            'season_key' => null,
             'total_matches' => 1102,
         ]);
         GamePlayer::factory()


### PR DESCRIPTION
Had a user complain they should be on the service based leaderboards.

Investigate and saw were using the old deprecated `season_number` key.

```
MariaDB [leafapp_infinite]> select id,player_id,mode,season_number,season_key,medal_count from service_records where player_id=407668;
+-------+-----------+------+---------------+------------+-------------+
| id    | player_id | mode | season_number | season_key | medal_count |
+-------+-----------+------+---------------+------------+-------------+
| 82907 |    407668 |    1 |             1 | NULL       |      145247 |
| 88481 |    407668 |    1 |             1 | 1-1        |       10746 |
| 88482 |    407668 |    1 |             1 | 1-2        |       12311 |
| 88483 |    407668 |    1 |             1 | 2-1        |       50224 |
| 88484 |    407668 |    1 |             1 | 2-2        |       37463 |
| 85719 |    407668 |    1 |             1 | 3-1        |       29966 |
| 88485 |    407668 |    1 |             1 | 4-1        |        4537 |
| 82908 |    407668 |    3 |             1 | NULL       |       16465 |
+-------+-----------+------+---------------+------------+-------------+
8 rows in set (0.001 sec)

MariaDB [leafapp_infinite]> 
```