### PR TITLE
fix: allow more than 10 tied places

### DIFF
--- a/app/Http/Livewire/TopTenLeaderboard.php
+++ b/app/Http/Livewire/TopTenLeaderboard.php
@@ -29,6 +29,7 @@ class TopTenLeaderboard extends Component
             ->with(['player', 'game', 'map'])
             ->where('key', $this->analyticKey)
             ->orderBy('place')
+            ->orderByDesc('id')
             ->paginate(10);
 
         $analyticEnumKey = AnalyticKey::tryFrom($this->analyticKey);


### PR DESCRIPTION
This will fix a reported issue on Twitter where Uvinity was twice. We only ordered by place with there was 11 - so nothing to enforce the order of those tied places.