### PR TITLE
feat: support Super-iteration of gametypes on Playlists

### DIFF
--- a/app/Support/Rotations/RotationResult.php
+++ b/app/Support/Rotations/RotationResult.php
@@ -28,6 +28,9 @@ class RotationResult
         [$gametypeName, $mapName] = explode(' on ', $this->name);
 
         $this->gametypeName = Str::after($gametypeName, ':');
+        if (Str::contains($gametypeName, 'Super') && ! Str::contains($this->gametypeName, 'Super')) {
+            $this->gametypeName .= ' (Super)';
+        }
         $this->mapName = $mapName;
     }
 

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -33,6 +33,11 @@ class PlaylistFactory extends Factory
                     'name' => 'Arena:CTF on Map',
                     'weight' => 110,
                 ],
+                [
+                    'name' => 'Super Husky Raid:CTF on Map',
+                    'weight' => 110,
+                ],
+
             ],
             'image_url' => $this->faker->imageUrl,
         ];

--- a/tests/Mocks/Metadata/MockPlaylistsService.php
+++ b/tests/Mocks/Metadata/MockPlaylistsService.php
@@ -16,7 +16,7 @@ class MockPlaylistsService extends BaseMock
         return [
             'data' => [
                 $this->playlist(),
-                $this->playlist(),
+                $this->playlist('Super Husky Raid:CTF on Smallhalla'),
                 $this->playlist(),
                 $this->playlist(),
                 $this->playlist(),
@@ -30,7 +30,7 @@ class MockPlaylistsService extends BaseMock
         ];
     }
 
-    private function playlist(): array
+    private function playlist(string $name = null): array
     {
         return [
             'id' => $this->faker->uuid,
@@ -56,7 +56,7 @@ class MockPlaylistsService extends BaseMock
             ],
             'rotation' => [
                 [
-                    'name' => $this->faker->word,
+                    'name' => $name ?? $this->faker->word,
                     'weight' => $this->faker->numberBetween(100, 115),
                 ],
             ],


### PR DESCRIPTION
This will fix issues where like Fiesta has duplicate Slayer events. We stripped stuff before colon as it was duplicating of playlist name, in this case its not.