### PR TITLE
fix: avoid ff matches in top ten

### DIFF
--- a/app/Support/Analytics/BaseGameStat.php
+++ b/app/Support/Analytics/BaseGameStat.php
@@ -19,4 +19,13 @@ class BaseGameStat
     {
         return GamePlayer::query();
     }
+
+    public function getPlaylistsToIgnore(): array
+    {
+        return [
+            config('services.halo.playlists.bot-bootcamp'),
+            config('services.halo.playlists.firefight-koth'),
+            config('services.halo.playlists.firefight-heroic'),
+        ];
+    }
 }

--- a/app/Support/Analytics/Stats/MostAssistsInGame.php
+++ b/app/Support/Analytics/Stats/MostAssistsInGame.php
@@ -50,7 +50,7 @@ class MostAssistsInGame extends BaseGameStat implements AnalyticInterface
             ->leftJoin('players', 'players.id', '=', 'game_players.player_id')
             ->leftJoin('games', 'game_players.game_id', '=', 'games.id')
             ->leftJoin('playlists', 'games.playlist_id', '=', 'playlists.id')
-            ->where('playlists.uuid', '!=', config('services.halo.playlists.bot-bootcamp'))
+            ->whereNotIn('playlists.uuid', $this->getPlaylistsToIgnore())
             ->where('players.is_cheater', false)
             ->where('players.is_bot', false)
             ->whereNotNull('games.playlist_id')

--- a/app/Support/Analytics/Stats/MostDeathsInGame.php
+++ b/app/Support/Analytics/Stats/MostDeathsInGame.php
@@ -53,7 +53,7 @@ class MostDeathsInGame extends BaseGameStat implements AnalyticInterface
             ->where('players.is_cheater', false)
             ->where('players.is_bot', false)
             ->whereNotNull('games.playlist_id')
-            ->where('playlists.uuid', '!=', config('services.halo.playlists.bot-bootcamp'))
+            ->whereNotIn('playlists.uuid', $this->getPlaylistsToIgnore())
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostKillsInGame.php
+++ b/app/Support/Analytics/Stats/MostKillsInGame.php
@@ -53,7 +53,7 @@ class MostKillsInGame extends BaseGameStat implements AnalyticInterface
             ->where('players.is_cheater', false)
             ->where('players.is_bot', false)
             ->whereNotNull('games.playlist_id')
-            ->where('playlists.uuid', '!=', config('services.halo.playlists.bot-bootcamp'))
+            ->whereNotIn('playlists.uuid', $this->getPlaylistsToIgnore())
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostKillsWithZeroDeathsGame.php
+++ b/app/Support/Analytics/Stats/MostKillsWithZeroDeathsGame.php
@@ -54,7 +54,7 @@ class MostKillsWithZeroDeathsGame extends BaseGameStat implements AnalyticInterf
             ->whereNotNull('games.playlist_id')
             ->leftJoin('games', 'game_players.game_id', '=', 'games.id')
             ->leftJoin('playlists', 'games.playlist_id', '=', 'playlists.id')
-            ->where('playlists.uuid', '!=', config('services.halo.playlists.bot-bootcamp'))
+            ->whereNotIn('playlists.uuid', $this->getPlaylistsToIgnore())
             ->orderByDesc($this->property())
             ->limit($limit)
             ->get();

--- a/app/Support/Analytics/Stats/MostMedalsInGame.php
+++ b/app/Support/Analytics/Stats/MostMedalsInGame.php
@@ -50,7 +50,7 @@ class MostMedalsInGame extends BaseGameStat implements AnalyticInterface
             ->leftJoin('players', 'players.id', '=', 'game_players.player_id')
             ->leftJoin('games', 'game_players.game_id', '=', 'games.id')
             ->leftJoin('playlists', 'games.playlist_id', '=', 'playlists.id')
-            ->where('playlists.uuid', '!=', config('services.halo.playlists.bot-bootcamp'))
+            ->whereNotIn('playlists.uuid', $this->getPlaylistsToIgnore())
             ->where('players.is_cheater', false)
             ->where('players.is_bot', false)
             ->where('players.is_botfarmer', false)

--- a/config/services.php
+++ b/config/services.php
@@ -73,6 +73,8 @@ return [
     'halo' => [
         'playlists' => [
             'bot-bootcamp' => env('HALO_PLAYLISTS_BOT_BOOTCAMP', 'a446725e-b281-414c-a21e-31b8700e95a1'),
+            'firefight-koth' => env('HALO_PLAYLISTS_FF_KOTH', '96aedf55-1c7e-46d5-bdaf-19a1329fb95d'),
+            'firefight-heroic' => env('HALO_PLAYLISTS_FF_HEROIC', 'd8ac67e8-647c-4602-8af0-f42012ba8dd8'),
         ],
         'botfarmer_threshold' => env('HALO_BOTFARMER_THRESHOLD', .50),
     ],


### PR DESCRIPTION
Meant to do this, but forgot about it. Someone on Twitter called out the Top Ten being useless because of FF.