### PR TITLE
fix: let livewire load itself

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {!! Artesaos\SEOTools\Facades\SEOTools::generate() !!}
     @vite(['resources/sass/app.scss', 'resources/js/app.js'])
-    <livewire:styles />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -20,6 +19,5 @@
         @yield('content')
     </main>
     @include('partials.global.footer')
-    <livewire:scripts />
 </body>
 </html>


### PR DESCRIPTION
All of Livewire broke somehow - I guess we missed a step in the upgrade guide. Which makes me doubt letting Livewire load itself. We could increase performance by packing that into JS that is handled via nginx.