### PR TITLE
fix: inject gamertag into ban message

### DIFF
--- a/app/Models/PlayerBan.php
+++ b/app/Models/PlayerBan.php
@@ -37,6 +37,16 @@ class PlayerBan extends Model implements HasDotApi
 
     public $timestamps = false;
 
+    public function getMessageAttribute(string $value): string
+    {
+        $replacements = [
+            'You have' => $this->player->gamertag  . ' has',
+            'Your' => $this->player->gamertag . "'s",
+        ];
+
+        return (string)str_replace(array_keys($replacements), $replacements, $value);
+    }
+
     public static function fromDotApi(array $payload): ?self
     {
         /** @var Player $player */

--- a/app/Models/PlayerBan.php
+++ b/app/Models/PlayerBan.php
@@ -40,11 +40,11 @@ class PlayerBan extends Model implements HasDotApi
     public function getMessageAttribute(string $value): string
     {
         $replacements = [
-            'You have' => $this->player->gamertag  . ' has',
-            'Your' => $this->player->gamertag . "'s",
+            'You have' => $this->player->gamertag.' has',
+            'Your' => $this->player->gamertag."'s",
         ];
 
-        return (string)str_replace(array_keys($replacements), $replacements, $value);
+        return (string) str_replace(array_keys($replacements), $replacements, $value);
     }
 
     public static function fromDotApi(array $payload): ?self


### PR DESCRIPTION
Twitter person was confused on the wording - since its in perspective of the banned individual. I'll rewrite messages on the fly to their gamertag.


![Screenshot from 2024-04-04 06-50-19](https://github.com/iBotPeaches/LeafApp_Infinite/assets/611784/3c86be39-4d6e-4d99-afd0-6ece2707c9db)
