### PR TITLE
fix: add unknown experience

### DIFF
--- a/app/Enums/Experience.php
+++ b/app/Enums/Experience.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
  * @method static static PVE_BOTS()
  * @method static static CUSTOM()
  * @method static static FEATURED()
+ * @method static static UNKNOWN()
  */
 final class Experience extends Enum implements LocalizedEnum
 {
@@ -26,6 +27,8 @@ final class Experience extends Enum implements LocalizedEnum
     const CUSTOM = 4;
 
     const FEATURED = 5;
+
+    const UNKNOWN = 6;
 
     public static function coerce(mixed $enumKeyOrValue): ?static
     {

--- a/resources/lang/en/enums.php
+++ b/resources/lang/en/enums.php
@@ -18,6 +18,7 @@ return [
         Experience::PVE_BOTS => 'PVE Bots',
         Experience::CUSTOM => 'Custom',
         Experience::FEATURED => 'Featured',
+        Experience::UNKNOWN => 'Unknown',
     ],
     Outcome::class => [
         Outcome::WIN => 'Win',


### PR DESCRIPTION
Influx of 1k+ failed games due to a new experience type - not sure what it could be. I'll have to find a game and pass to @Alexis-Bize.