### PR TITLE
fix: prevent scrolling on pagination change

### DIFF
--- a/resources/views/livewire/championships-table.blade.php
+++ b/resources/views/livewire/championships-table.blade.php
@@ -28,5 +28,5 @@
             </tbody>
         </table>
     </div>
-    {{ $championships->links() }}
+    {{ $championships->links(data: ['scrollTo' => false]) }}
 </div>

--- a/resources/views/livewire/game-custom-history-table.blade.php
+++ b/resources/views/livewire/game-custom-history-table.blade.php
@@ -76,6 +76,6 @@
                 </tbody>
             </table>
         </div>
-        {{ $games->links() }}
+        {{ $games->links(data: ['scrollTo' => false]) }}
     @endif
 </div>

--- a/resources/views/livewire/game-history-table.blade.php
+++ b/resources/views/livewire/game-history-table.blade.php
@@ -78,5 +78,5 @@
             </tbody>
         </table>
     </div>
-    {{ $games->links() }}
+    {{ $games->links(data: ['scrollTo' => false]) }}
 </div>

--- a/resources/views/livewire/game-lan-history-table.blade.php
+++ b/resources/views/livewire/game-lan-history-table.blade.php
@@ -76,6 +76,6 @@
                 </tbody>
             </table>
         </div>
-        {{ $games->links() }}
+        {{ $games->links(data: ['scrollTo' => false]) }}
     @endif
 </div>

--- a/resources/views/livewire/medals-leaderboard.blade.php
+++ b/resources/views/livewire/medals-leaderboard.blade.php
@@ -72,6 +72,6 @@
                 </tbody>
             </table>
         </div>
-        {{ $results->links() }}
+        {{ $results->links(data: ['scrollTo' => false]) }}
     @endif
 </div>

--- a/resources/views/livewire/medals-table.blade.php
+++ b/resources/views/livewire/medals-table.blade.php
@@ -47,5 +47,5 @@
             </tbody>
         </table>
     </div>
-    {{ $medals->links() }}
+    {{ $medals->links(data: ['scrollTo' => false]) }}
 </div>

--- a/resources/views/livewire/scrims-table.blade.php
+++ b/resources/views/livewire/scrims-table.blade.php
@@ -34,5 +34,5 @@
             </tbody>
         </table>
     </div>
-    {{ $scrims->links() }}
+    {{ $scrims->links(data: ['scrollTo' => false]) }}
 </div>

--- a/resources/views/livewire/top-ten-leaderboard.blade.php
+++ b/resources/views/livewire/top-ten-leaderboard.blade.php
@@ -83,7 +83,7 @@ use App\Support\Analytics\Stats\MostXpPlayer;
                 </tbody>
             </table>
         </div>
-        {{ $results->links() }}
+        {{ $results->links(data: ['scrollTo' => false]) }}
         <div class="notification is-light is-hidden-mobile mt-2">
             export to csv: <a href="{{ $analyticClass->displayExportUrl(10) }}" rel="nofollow">top 10</a>,
             <a href="{{ $analyticClass->displayExportUrl(100) }}" rel="nofollow">top 100</a> or

--- a/resources/views/livewire/top-ten-table.blade.php
+++ b/resources/views/livewire/top-ten-table.blade.php
@@ -24,5 +24,5 @@
             </tbody>
         </table>
     </div>
-    {{ $stats->links() }}
+    {{ $stats->links(data: ['scrollTo' => false]) }}
 </div>


### PR DESCRIPTION
Requested on Twitter to stop moving table on pagination changes.