### PR TITLE
Support for partial bans.

### DIFF
--- a/app/Console/Commands/CheckForUnban.php
+++ b/app/Console/Commands/CheckForUnban.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Player;
+use Illuminate\Console\Command;
+
+class CheckForUnban extends Command
+{
+    protected $signature = 'app:check-for-unban';
+
+    protected $description = 'Command description';
+
+    public function handle(): int
+    {
+        $cursor = Player::query()
+            ->where('is_cheater', true)
+            ->whereHas('bans', function ($query) {
+                $query->where('ends_at', '<', now());
+            })
+            ->cursor();
+
+        foreach ($cursor as $player) {
+            $player->is_cheater = false;
+            $player->saveOrFail();
+
+            $this->info("Player {$player->gamertag} has been unbanned.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/PlayerBan.php
+++ b/app/Models/PlayerBan.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
  * @property string $type
  * @property string $scope
  * @property-read Player $player
+ * @property-read bool $is_expired
  *
  * @method static PlayerBanFactory factory(...$parameters)
  */
@@ -39,12 +40,18 @@ class PlayerBan extends Model implements HasDotApi
 
     public function getMessageAttribute(string $value): string
     {
+        $word = $this->is_expired ? 'had' : 'has';
         $replacements = [
-            'You have' => $this->player->gamertag.' has',
+            'You have' => $this->player->gamertag.' '.$word,
             'Your' => $this->player->gamertag."'s",
         ];
 
         return (string) str_replace(array_keys($replacements), $replacements, $value);
+    }
+
+    public function getIsExpiredAttribute(): bool
+    {
+        return $this->ends_at->isPast();
     }
 
     public static function fromDotApi(array $payload): ?self

--- a/resources/views/partials/player/ban-header.blade.php
+++ b/resources/views/partials/player/ban-header.blade.php
@@ -3,12 +3,14 @@
 ?>
 @if ($player->bans)
     @foreach ($player->bans as $ban)
-        <div class="notification is-danger">
+        <div class="notification {{ $ban->is_expired ? 'is-warning' : 'is-danger' }}">
             {{ $ban->message }}
-            <br /><br />
-            <p class="is-size-7">
-                Days remaining: {{ number_format($ban->ends_at->diffInDays(absolute: true)) }}, for '{{ $ban->type }}', on scope: '{{ $ban->scope }}'
-            </p>
+            @if (! $ban->is_expired)
+                <br /><br />
+                <p class="is-size-7">
+                    Days remaining: {{ number_format($ban->ends_at->diffInDays(absolute: true)) }}, for '{{ $ban->type }}', on scope: '{{ $ban->scope }}'
+                </p>
+            @endif
         </div>
     @endforeach
 @endif

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CheckForUnban;
 use App\Console\Commands\PullMetadata;
 use App\Console\Commands\RefreshAnalytics;
 use App\Console\Commands\RefreshMedals;
@@ -22,3 +23,7 @@ Schedule::command(RefreshMedals::class)
 
 Schedule::command(SnapshotCommand::class)
     ->everyFiveMinutes();
+
+Schedule::command(CheckForUnban::class)
+    ->daily()
+    ->withoutOverlapping();

--- a/tests/Feature/Console/CheckForUnbanTest.php
+++ b/tests/Feature/Console/CheckForUnbanTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Player;
+use App\Models\PlayerBan;
+use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Console\Command\Command as CommandAlias;
+use Tests\TestCase;
+
+class CheckForUnbanTest extends TestCase
+{
+    use WithFaker;
+
+    public function testUnbanning(): void
+    {
+        // Arrange
+        $playerBan = PlayerBan::factory()
+            ->for(Player::factory()->state(['is_cheater' => true]))
+            ->createOne([
+                'ends_at' => now()->subDay(),
+            ]);
+
+        // Act & Assert
+        $this
+            ->artisan('app:check-for-unban')
+            ->assertExitCode(CommandAlias::SUCCESS)
+            ->expectsOutput("Player {$playerBan->player->gamertag} has been unbanned.");
+    }
+
+    public function testUnbanFailsOnActiveCheater(): void
+    {
+        // Arrange
+        $playerBan = PlayerBan::factory()
+            ->for(Player::factory()->state(['is_cheater' => true]))
+            ->createOne([
+                'ends_at' => now()->addDay(),
+            ]);
+
+        // Act & Assert
+        $this
+            ->artisan('app:check-for-unban')
+            ->assertExitCode(CommandAlias::SUCCESS)
+            ->doesntExpectOutput("Player {$playerBan->player->gamertag} has been unbanned.");
+    }
+}


### PR DESCRIPTION
![Screenshot from 2024-04-05 19-32-46](https://github.com/iBotPeaches/LeafApp_Infinite/assets/611784/f8da8a49-e1ef-4482-8b5f-3d15080c8875)

![Screenshot from 2024-04-05 19-32-39](https://github.com/iBotPeaches/LeafApp_Infinite/assets/611784/53e588e3-4712-4fd8-b9bd-7e967888ecaa)

With bans flying like crazy (50+ in 48 hours) I saw some were forever (till year 9999) while others were 6 month bans. This adds support for an expiring ban that checks nightly.