### PR TITLE
fix: treat timeout as failure

### DIFF
--- a/app/Jobs/PullAppearance.php
+++ b/app/Jobs/PullAppearance.php
@@ -25,6 +25,8 @@ class PullAppearance implements ShouldQueue
 
     public int $tries = 1;
 
+    public bool $failOnTimeout = true;
+
     public Player $player;
 
     public function __construct(Player $player)

--- a/app/Jobs/PullCompetitive.php
+++ b/app/Jobs/PullCompetitive.php
@@ -22,6 +22,8 @@ class PullCompetitive implements ShouldQueue
 
     public int $timeout = 60;
 
+    public bool $failOnTimeout = true;
+
     private Player $player;
 
     private ?string $seasonKey;

--- a/app/Jobs/PullLogoFromMatchupTeam.php
+++ b/app/Jobs/PullLogoFromMatchupTeam.php
@@ -22,6 +22,8 @@ class PullLogoFromMatchupTeam implements ShouldQueue
 
     public int $tries = 1;
 
+    public bool $failOnTimeout = true;
+
     public MatchupTeam $matchupTeam;
 
     public string $avatar;

--- a/app/Jobs/PullMatchHistory.php
+++ b/app/Jobs/PullMatchHistory.php
@@ -23,6 +23,8 @@ class PullMatchHistory implements ShouldQueue
 
     public int $timeout = 720;
 
+    public bool $failOnTimeout = true;
+
     private Player $player;
 
     public Mode $mode;

--- a/app/Jobs/PullServiceRecord.php
+++ b/app/Jobs/PullServiceRecord.php
@@ -22,6 +22,8 @@ class PullServiceRecord implements ShouldQueue
 
     public int $timeout = 720;
 
+    public bool $failOnTimeout = true;
+
     private Player $player;
 
     private ?string $seasonIdentifier;

--- a/app/Jobs/PullXuid.php
+++ b/app/Jobs/PullXuid.php
@@ -23,6 +23,8 @@ class PullXuid implements ShouldQueue
 
     public int $retryAfter = 0;
 
+    public bool $failOnTimeout = true;
+
     public function __construct(Player $player)
     {
         $this->player = $player;


### PR DESCRIPTION
This will prevent a job from hitting timeout (getting killed) and retrying, then failing as "max attempts reached". It'll be easier to detect if our timeouts are too small.