### PR TITLE
fix: remove "- Ranked" from map name

### DIFF
--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
  * @property string $name
  * @property string $thumbnail_url
  * @property-read string $image
+ * @property-read string $shorthand
  * @property-read Level|null $level
  *
  * @method static MapFactory factory(...$parameters)
@@ -42,6 +43,11 @@ class Map extends Model implements HasDotApi
         }
 
         return $this->thumbnail_url;
+    }
+
+    public function getShorthandAttribute(): string
+    {
+        return Str::remove('- Ranked', $this->name);
     }
 
     public static function fromDotApi(array $payload): ?self

--- a/resources/views/livewire/game-custom-history-table.blade.php
+++ b/resources/views/livewire/game-custom-history-table.blade.php
@@ -38,7 +38,7 @@
                         <td>
                             <a href="{{ route('game', [$game]) }}">
                                 <abbr title="{{ $game->map->name }}">
-                                    {{ \Illuminate\Support\Str::limit($game->map->name, 15) }}
+                                    {{ \Illuminate\Support\Str::limit($game->map->shorthand, 15) }}
                                 </abbr>
                             </a>
                         </td>

--- a/resources/views/livewire/game-history-table.blade.php
+++ b/resources/views/livewire/game-history-table.blade.php
@@ -38,7 +38,7 @@
                     </td>
                     <td>
                         <abbr title="{{ $game->map->name }}">
-                            {{ \Illuminate\Support\Str::limit($game->map->name, 15) }}
+                            {{ \Illuminate\Support\Str::limit($game->map->shorthand, 15) }}
                         </abbr>
                     </td>
                     <td>

--- a/resources/views/livewire/game-lan-history-table.blade.php
+++ b/resources/views/livewire/game-lan-history-table.blade.php
@@ -38,7 +38,7 @@
                         <td>
                             <a href="{{ route('game', [$game]) }}">
                                 <abbr title="{{ $game->map->name }}">
-                                    {{ \Illuminate\Support\Str::limit($game->map->name, 15) }}
+                                    {{ \Illuminate\Support\Str::limit($game->map->shorthand, 15) }}
                                 </abbr>
                             </a>
                         </td>

--- a/resources/views/livewire/top-ten-leaderboard.blade.php
+++ b/resources/views/livewire/top-ten-leaderboard.blade.php
@@ -73,7 +73,7 @@ use App\Support\Analytics\Stats\MostXpPlayer;
                             </td>
                         @endif
                         @if ($analyticClass->type()->isMap())
-                            <td>{{ $result->map->name }}</td>
+                            <td>{{ $result->map->shorthand }}</td>
                         @endif
                         <td>{{ $analyticClass->displayProperty($result) }}</td>
                         @if ($analyticClass->type()->isGame())

--- a/resources/views/partials/game/game-card.blade.php
+++ b/resources/views/partials/game/game-card.blade.php
@@ -20,7 +20,7 @@
     <div class="card-content">
         <div class="media">
             <div class="media-content">
-                <h1 class="title is-4">{{ $game->map->name }}</h1>
+                <h1 class="title is-4">{{ $game->map->shorthand }}</h1>
                 <h2 class="subtitle is-6">
                     <span class="has-tooltip-arrow" data-tooltip="Base Mode: {{ $game->gamevariant?->category?->name ?? 'Unknown Gametype' }}">
                         {{ $game->gamevariant?->name ?? $game->category?->name }}

--- a/resources/views/partials/hcs/game_breakdown/ffa.blade.php
+++ b/resources/views/partials/hcs/game_breakdown/ffa.blade.php
@@ -12,7 +12,7 @@
             <article class="tile is-child notification is-dark">
                 <p class="title">
                     <a href="{{ route('game', [$game]) }}">
-                        {{ $game->map->name }}
+                        {{ $game->map->shorthand }}
                     </a>
                 </p>
                 <p class="subtitle">{{ $game->gamevariant?->name ?? $game->category?->name }}</p>

--- a/resources/views/partials/player/mode-table.blade.php
+++ b/resources/views/partials/player/mode-table.blade.php
@@ -19,7 +19,7 @@
         @foreach ($mode as $game)
             <tr>
                 <td>
-                    {{ $game->map->name }} {{ $game->category?->name ?? 'Unknown' }}
+                    {{ $game->map->shorthand }} {{ $game->category?->name ?? 'Unknown' }}
                 </td>
                 <td>{{ number_format($game->percentWon, 2) }}%</td>
                 <td>{{ $game->summedTotal }}</td>

--- a/resources/views/partials/scrim/matches_breakdown/ffa.blade.php
+++ b/resources/views/partials/scrim/matches_breakdown/ffa.blade.php
@@ -6,7 +6,7 @@ $winningPlayer = $game->players->sortBy('rank')->first();
 <article class="tile is-child notification is-dark">
     <p class="title">
         <a href="{{ route('game', [$game]) }}">
-            {{ $game->map->name }}
+            {{ $game->map->shorthand }}
         </a>
         @if ($winningPlayer)
             <span class="is-pulled-right">

--- a/resources/views/partials/scrim/matches_breakdown/team.blade.php
+++ b/resources/views/partials/scrim/matches_breakdown/team.blade.php
@@ -4,7 +4,7 @@
 <article class="tile is-child notification {{ $game->winner?->color }}">
     <p class="title">
         <a href="{{ route('game', [$game]) }}">
-            {{ $game->map->name }}
+            {{ $game->map->shorthand }}
         </a>
         <span class="is-pulled-right">
             <span class="tag is-dark">{{ $game->score }}</span>


### PR DESCRIPTION
Another request from Twitter to remove the annoying "- Ranked" from map names. While I do agree the Ranked iteration of the maps are different you can determine that from the playlist.