### PR TITLE
fix: detect grunt ff for bot farmer detection

### DIFF
--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -278,6 +278,9 @@ class Player extends Model implements HasDotApi, Sitemapable
             config('services.halo.playlists.firefight-koth'),
             config('services.halo.playlists.firefight-heroic'),
             config('services.halo.playlists.firefight-legendary'),
+            config('services.halo.playlists.firefight-grunt-koth'),
+            config('services.halo.playlists.firefight-grunt-heroic'),
+            config('services.halo.playlists.firefight-grunt-legendary'),
         ];
 
         // Check for "Bot Farmer" status - aka a ton of Bot Bootcamp


### PR DESCRIPTION
This pull request includes a change to the `updateFromDotApi` function in the `app/Models/Player.php` file. Three new game playlists have been added to the configuration array: `firefight-grunt-koth`, `firefight-grunt-heroic`, and `firefight-grunt-legendary`.