### PR TITLE
chore: drop saveOrFail() for save()

### DIFF
--- a/app/Console/Commands/CheckForUnban.php
+++ b/app/Console/Commands/CheckForUnban.php
@@ -22,7 +22,7 @@ class CheckForUnban extends Command
 
         foreach ($cursor as $player) {
             $player->is_cheater = false;
-            $player->saveOrFail();
+            $player->save();
 
             $this->info("Player {$player->gamertag} has been unbanned.");
         }

--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -30,7 +30,7 @@ class GoogleController extends Controller
                 'google_id' => $googleUser->getId(),
             ]);
 
-        $user->saveOrFail();
+        $user->save();
         Auth::login($user, true);
 
         if ($user->player) {

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -65,7 +65,7 @@ class PlayerController extends Controller
         /** @var User $user */
         $user = $request->user();
         $user->player()->associate($player);
-        $user->saveOrFail();
+        $user->save();
 
         return redirect()->route('player', $player);
     }
@@ -75,7 +75,7 @@ class PlayerController extends Controller
         /** @var User $user */
         $user = $request->user();
         $user->player_id = null;
-        $user->saveOrFail();
+        $user->save();
 
         return redirect()->route('player', $player);
     }

--- a/app/Jobs/FindMatchesFromMatchup.php
+++ b/app/Jobs/FindMatchesFromMatchup.php
@@ -86,7 +86,7 @@ class FindMatchesFromMatchup implements ShouldQueue
 
                     $matchupGame->game()->associate($game);
                     $matchupGame->matchup()->associate($this->matchup);
-                    $matchupGame->saveOrFail();
+                    $matchupGame->save();
 
                     $this->processedGameIds[] = $game->id;
                 });

--- a/app/Jobs/FindPlayersFromTeam.php
+++ b/app/Jobs/FindPlayersFromTeam.php
@@ -49,7 +49,7 @@ class FindPlayersFromTeam implements ShouldQueue
 
             if ($player) {
                 $teamPlayer->player()->associate($player);
-                $teamPlayer->saveOrFail();
+                $teamPlayer->save();
             }
         }
     }

--- a/app/Jobs/ProcessAnalytic.php
+++ b/app/Jobs/ProcessAnalytic.php
@@ -81,7 +81,7 @@ class ProcessAnalytic implements ShouldQueue
             $analytic->place = $index + 1;
             $analytic->value = (float) $game->{$this->analytic->property()};
             $analytic->game()->associate($game);
-            $analytic->saveOrFail();
+            $analytic->save();
         });
     }
 
@@ -104,7 +104,7 @@ class ProcessAnalytic implements ShouldQueue
             $analytic->value = $value;
             $analytic->game()->associate($gamePlayer->game);
             $analytic->player()->associate($gamePlayer->player);
-            $analytic->saveOrFail();
+            $analytic->save();
 
             // Store our last values in case users share the value.
             $lastIndex = $analytic->place;
@@ -130,7 +130,7 @@ class ProcessAnalytic implements ShouldQueue
             $analytic->place = $place;
             $analytic->value = $value;
             $analytic->player()->associate($serviceRecord->player);
-            $analytic->saveOrFail();
+            $analytic->save();
 
             // Store our last values in case users share the value.
             $lastIndex = $analytic->place;
@@ -147,7 +147,7 @@ class ProcessAnalytic implements ShouldQueue
             $analytic->place = $index + 1;
             $analytic->value = (float) $map->{$this->analytic->property()};
             $analytic->map()->associate($map);
-            $analytic->saveOrFail();
+            $analytic->save();
         });
     }
 

--- a/app/Jobs/ProcessScrim.php
+++ b/app/Jobs/ProcessScrim.php
@@ -33,6 +33,6 @@ class ProcessScrim implements ShouldQueue
         });
 
         $this->scrim->is_complete = true;
-        $this->scrim->saveOrFail();
+        $this->scrim->save();
     }
 }

--- a/app/Jobs/PullXuid.php
+++ b/app/Jobs/PullXuid.php
@@ -63,7 +63,7 @@ class PullXuid implements ShouldQueue
             if ($this->player->xuid) {
                 $this->checkForGamertagChange();
             }
-            $this->player->saveOrFail();
+            $this->player->save();
         }
     }
 }

--- a/app/Livewire/UpdatePlayerPanel.php
+++ b/app/Livewire/UpdatePlayerPanel.php
@@ -68,7 +68,7 @@ class UpdatePlayerPanel extends Component
                     $this->player->lockForUpdate();
                     $this->player->updateFromDotApi(false, $this->type);
                     if ($this->player->isDirty()) {
-                        $this->player->saveOrFail();
+                        $this->player->save();
                     }
                 }, 3);
             } catch (RequestException $exception) {

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -63,7 +63,7 @@ class Category extends Model implements HasDotApi, HasDotApiMetadata
         $category->thumbnail_url = Arr::get($payload, 'image_urls.thumbnail');
 
         if ($category->isDirty()) {
-            $category->saveOrFail();
+            $category->save();
         }
 
         return $category;

--- a/app/Models/Championship.php
+++ b/app/Models/Championship.php
@@ -128,7 +128,7 @@ class Championship extends Model implements HasFaceItApi, Sitemapable
         $championship->description = Arr::get($payload, 'description');
 
         if ($championship->isDirty()) {
-            $championship->saveOrFail();
+            $championship->save();
         }
 
         return $championship;

--- a/app/Models/Csr.php
+++ b/app/Models/Csr.php
@@ -251,7 +251,7 @@ class Csr extends Model implements HasDotApi
                 $csr->next_csr = Arr::get($playlistMode, 'next_tier_start');
 
                 if ($csr->isDirty()) {
-                    $csr->saveOrFail();
+                    $csr->save();
                 }
             }
         }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -224,7 +224,7 @@ class Game extends Model implements HasDotApi
         }
 
         if ($game->isDirty()) {
-            $game->saveOrFail();
+            $game->save();
         }
 
         if (Arr::has($payload, 'teams.0.id')) {
@@ -243,7 +243,7 @@ class Game extends Model implements HasDotApi
                 // re-process later.
                 if ($type === PlayerType::PLAYER && (bool) Arr::get($playerData, 'attributes.resolved') === false) {
                     $game->was_pulled = false;
-                    $game->saveOrFail();
+                    $game->save();
 
                     continue;
                 }
@@ -251,7 +251,7 @@ class Game extends Model implements HasDotApi
                 $player = Player::fromGamertag($gamertag);
                 if (! $player->exists) {
                     $player->is_bot = $type === PlayerType::BOT;
-                    $player->saveOrFail();
+                    $player->save();
                     PullAppearance::dispatch($player);
                 }
                 $playerData['_leaf']['player'] = $player;

--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -164,7 +164,7 @@ class GamePlayer extends Model implements HasDotApi
         }
 
         if ($gamePlayer->isDirty()) {
-            $gamePlayer->saveOrFail();
+            $gamePlayer->save();
         }
 
         return $gamePlayer;

--- a/app/Models/GameTeam.php
+++ b/app/Models/GameTeam.php
@@ -116,7 +116,7 @@ class GameTeam extends Model implements HasDotApi
         $gameTeam->final_score = Arr::get($payload, $key);
 
         if ($gameTeam->isDirty()) {
-            $gameTeam->saveOrFail();
+            $gameTeam->save();
         }
 
         return $gameTeam;

--- a/app/Models/Gamevariant.php
+++ b/app/Models/Gamevariant.php
@@ -49,7 +49,7 @@ class Gamevariant extends Model implements HasDotApi
         $gamevariant->category()->associate($category);
 
         if ($gamevariant->isDirty()) {
-            $gamevariant->saveOrFail();
+            $gamevariant->save();
         }
 
         return $gamevariant;

--- a/app/Models/Level.php
+++ b/app/Models/Level.php
@@ -68,7 +68,7 @@ class Level extends Model implements HasDotApi, HasDotApiMetadata
         $level->thumbnail_url = Arr::get($payload, 'image_urls.thumbnail');
 
         if ($level->isDirty()) {
-            $level->saveOrFail();
+            $level->save();
         }
 
         return $level;

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -69,7 +69,7 @@ class Map extends Model implements HasDotApi
         $map->level()->associate($level);
 
         if ($map->isDirty()) {
-            $map->saveOrFail();
+            $map->save();
         }
 
         return $map;

--- a/app/Models/Matchup.php
+++ b/app/Models/Matchup.php
@@ -192,7 +192,7 @@ class Matchup extends Model implements HasFaceItApi, Sitemapable
         $matchup->ended_at = Arr::get($payload, 'finished_at');
 
         if ($matchup->isDirty()) {
-            $matchup->saveOrFail();
+            $matchup->save();
         }
 
         return $matchup;

--- a/app/Models/MatchupTeam.php
+++ b/app/Models/MatchupTeam.php
@@ -102,7 +102,7 @@ class MatchupTeam extends Model implements HasFaceItApi
         $team->outcome = $winner ? ($winner === $teamInternalId ? Outcome::WIN() : Outcome::LOSS()) : Outcome::DRAW();
 
         if ($team->isDirty()) {
-            $team->saveOrFail();
+            $team->save();
         }
 
         PullLogoFromMatchupTeam::dispatchSync($team, Arr::get($payload, 'avatar'));

--- a/app/Models/Medal.php
+++ b/app/Models/Medal.php
@@ -123,7 +123,7 @@ class Medal extends Model implements HasDotApi, Sitemapable
         $medal->difficulty = Arr::get($payload, 'attributes.difficulty');
 
         if ($medal->isDirty()) {
-            $medal->saveOrFail();
+            $medal->save();
         }
 
         return $medal;

--- a/app/Models/Pivots/MatchupPlayer.php
+++ b/app/Models/Pivots/MatchupPlayer.php
@@ -55,7 +55,7 @@ class MatchupPlayer extends Pivot implements HasFaceItApi
         $teamPlayer->faceit_name = Arr::get($payload, 'game_player_id');
 
         if ($teamPlayer->isDirty()) {
-            $teamPlayer->saveOrFail();
+            $teamPlayer->save();
         }
 
         return $teamPlayer;

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -215,7 +215,7 @@ class Player extends Model implements HasDotApi, Sitemapable
         }
 
         if ($player->isDirty()) {
-            $player->saveOrFail();
+            $player->save();
         }
 
         return $player;
@@ -239,7 +239,7 @@ class Player extends Model implements HasDotApi, Sitemapable
         }
 
         $this->is_cheater = true;
-        $this->saveOrFail();
+        $this->save();
 
         return $this->is_cheater;
     }

--- a/app/Models/PlayerBan.php
+++ b/app/Models/PlayerBan.php
@@ -79,7 +79,7 @@ class PlayerBan extends Model implements HasDotApi
         $playerBan->scope = Arr::get($payload, 'properties.scope');
 
         if ($playerBan->isDirty()) {
-            $playerBan->saveOrFail();
+            $playerBan->save();
         }
 
         return $playerBan;

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -102,7 +102,7 @@ class Playlist extends Model implements HasDotApi
         $playlist->image_url = Arr::get($payload, 'image_urls.thumbnail');
 
         if ($playlist->isDirty()) {
-            $playlist->saveOrFail();
+            $playlist->save();
         }
 
         return $playlist;

--- a/app/Models/Rank.php
+++ b/app/Models/Rank.php
@@ -86,7 +86,7 @@ class Rank extends Model implements HasDotApi
         $rank->required = max(0, $rank->threshold - $lastThreshold);
 
         if ($rank->isDirty()) {
-            $rank->saveOrFail();
+            $rank->save();
         }
 
         return $rank;

--- a/app/Models/Scrim.php
+++ b/app/Models/Scrim.php
@@ -36,7 +36,7 @@ class Scrim extends Model implements Sitemapable
     {
         $model = new self();
         $model->user()->associate($user);
-        $model->saveOrFail();
+        $model->save();
 
         $model->games()->sync($gameIds);
 

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -77,7 +77,7 @@ class Season extends Model implements HasDotApi
         $season->description = Arr::get($payload, 'description');
 
         if ($season->isDirty()) {
-            $season->saveOrFail();
+            $season->save();
         }
 
         return $season;

--- a/app/Models/ServiceRecord.php
+++ b/app/Models/ServiceRecord.php
@@ -215,11 +215,11 @@ class ServiceRecord extends Model implements HasDotApi
         // Old seasons shouldn't be used to determine private-ness, since new players will be marked as inactive.
         // Just flag the account if the all seasons (merged) returns no data.
         if ($serviceRecord->player->isDirty(['is_private']) && ($season === null || $season->key === SeasonSession::$allSeasonKey)) {
-            $serviceRecord->player->saveOrFail();
+            $serviceRecord->player->save();
         }
 
         if ($serviceRecord->isDirty() && ! $serviceRecord->player->is_private) {
-            $serviceRecord->saveOrFail();
+            $serviceRecord->save();
         }
 
         return $serviceRecord;

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -41,7 +41,7 @@ class Team extends Model implements HasDotApi
         $team->emblem_url = Arr::get($payload, 'image_urls.icon');
 
         if ($team->isDirty()) {
-            $team->saveOrFail();
+            $team->save();
         }
 
         return $team;

--- a/app/Services/DotApi/ApiClient.php
+++ b/app/Services/DotApi/ApiClient.php
@@ -125,7 +125,7 @@ class ApiClient implements InfiniteInterface
 
         // Save the Player with the latest game pulled (Custom vs Matchmaking)
         $player->$lastGameIdVariable = $firstPulledGameId ?? $player->$lastGameIdVariable;
-        $player->saveOrFail();
+        $player->save();
 
         return GamePlayer::query()
             ->where('player_id', $player->id)

--- a/tests/Feature/Forms/UpdatePlayerPanel/ValidPlayerUpdateTest.php
+++ b/tests/Feature/Forms/UpdatePlayerPanel/ValidPlayerUpdateTest.php
@@ -474,7 +474,7 @@ class ValidPlayerUpdateTest extends TestCase
             ]);
 
         $player->last_game_id_pulled = $gamePlayer->game_id;
-        $player->saveOrFail();
+        $player->save();
 
         // Act & Assert
         Livewire::test(UpdatePlayerPanel::class, [

--- a/tests/Unit/Models/PlayerModelTest.php
+++ b/tests/Unit/Models/PlayerModelTest.php
@@ -24,7 +24,7 @@ class PlayerModelTest extends TestCase
         ]);
 
         // Act
-        $player->saveOrFail();
+        $player->save();
 
         // Assert
         Bus::assertNotDispatched(PullXuid::class);
@@ -42,7 +42,7 @@ class PlayerModelTest extends TestCase
         ]);
 
         // Act
-        $player->saveOrFail();
+        $player->save();
 
         // Assert
         Bus::assertDispatched(PullXuid::class);


### PR DESCRIPTION
Recently learned (perhaps from my pivot from Yii2 -> Laravel 7 years ago) I never fully understood how `saveOrFail()` worked. In my head I thought it threw an exception on save fail (while `save`) just returned false.

This was wrong. `saveOrFail()` just wraps the save in a transaction to not commit on failure. We can review instances one by one where we need a transaction for a chained multi-model save, but at the moment I'm reverting all.