### PR TITLE
fix: strip " - Husky Raid" from map

### DIFF
--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -47,7 +47,12 @@ class Map extends Model implements HasDotApi
 
     public function getShorthandAttribute(): string
     {
-        return Str::trim(Str::remove('- Ranked', $this->name));
+        $suffixesToTrim = [
+            ' - Ranked',
+            ' - Husky Raid',
+        ];
+
+        return Str::trim(Str::remove($suffixesToTrim, $this->name));
     }
 
     public static function fromDotApi(array $payload): ?self


### PR DESCRIPTION
![Screenshot from 2024-04-21 21-16-06](https://github.com/iBotPeaches/LeafApp_Infinite/assets/611784/5066d832-4b10-4e76-a256-b9c05dd3d4a7)

* I don't think we should have Husky specific maps - they didn't start that way and normally Husky maps are custom so there is no chance of overlap with others.