### PR TITLE
fix: ensure most quit does not include customs

### DIFF
--- a/app/Jobs/ProcessAnalytic.php
+++ b/app/Jobs/ProcessAnalytic.php
@@ -60,12 +60,12 @@ class ProcessAnalytic implements ShouldQueue
                     break;
             }
 
-            foreach ([$topTen, $topHundred, $topThousand] as $resultSet) {
+            foreach ([10 => $topTen, 100 => $topHundred, 1_000 => $topThousand] as $amount => $resultSet) {
                 $writer = Writer::createFromString();
                 $writer->insertOne($this->analytic->csvHeader());
                 $writer->insertAll($this->analytic->csvData($resultSet));
 
-                $slug = $this->analytic->slug(count($resultSet ?? []));
+                $slug = $this->analytic->slug($amount);
 
                 Storage::disk('public')->put('top-ten/'.$slug.'.csv', $writer->toString());
             }

--- a/app/Support/Analytics/Stats/MostQuitMap.php
+++ b/app/Support/Analytics/Stats/MostQuitMap.php
@@ -49,6 +49,7 @@ class MostQuitMap extends BaseOverviewStatStat implements AnalyticInterface
             ->join('overviews', 'overview_stats.overview_id', '=', 'overviews.id')
             ->whereNull('overview_gametype_id')
             ->whereNull('overview_map_id')
+            ->where('overviews.is_manual', false)
             ->where('total_players', '>', 0)
             ->orderByDesc('percent_quit')
             ->having('percent_quit', '>', 0)


### PR DESCRIPTION
Reported by Okom and caused by assuming we'd have at least 1k events in the top ten.