### PR TITLE
fix: don't let assists go negative

### DIFF
--- a/app/Models/GamePlayer.php
+++ b/app/Models/GamePlayer.php
@@ -128,7 +128,7 @@ class GamePlayer extends Model implements HasDotApi
         $gamePlayer->mmr ??= Arr::get($payload, $prefix.'stats.mmr');
         $gamePlayer->kills = Arr::get($payload, $prefix.'stats.core.summary.kills');
         $gamePlayer->deaths = Arr::get($payload, $prefix.'stats.core.summary.deaths');
-        $gamePlayer->assists = Arr::get($payload, $prefix.'stats.core.summary.assists');
+        $gamePlayer->assists = max((int) Arr::get($payload, $prefix.'stats.core.summary.assists'), 0);
         $gamePlayer->betrayals = Arr::get($payload, $prefix.'stats.core.summary.betrayals');
         $gamePlayer->suicides = Arr::get($payload, $prefix.'stats.core.summary.suicides');
         $gamePlayer->max_spree = Arr::get($payload, $prefix.'stats.core.summary.max_killing_spree');


### PR DESCRIPTION
```
SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'assists' at row 1 (Connection: mysql, SQL: insert into `game_players` (`player_id`, `game_id`, `pre_csr`, `post_csr`, `matches_remaining`, `rank`, `outcome`, `was_at_start`, `was_at_end`, `was_inprogress_join`, `kd`, `kda`, `score`, `mmr`, `kills`, `deaths`, `assists`, `betrayals`, `suicides`, `max_spree`, `vehicle_destroys`, `vehicle_hijacks`, `medal_count`, `damage_taken`, `damage_dealt`, `shots_fired`, `shots_landed`, `shots_missed`, `accuracy`, `rounds_won`, `rounds_lost`, `rounds_tied`, `kills_melee`, `kills_grenade`, `kills_headshot`, `kills_power`, `assists_emp`, `assists_driver`, `assists_callout`, `expected_kills`, `expected_deaths`) values (9057, 44266607, ?, ?, ?, 1, 1, 1, 1, 0, 2, 5, 2000, ?, 10, 5, -100, 452, 0, 4, 0, 0, 2, 45, 97, 797, 10, 787, 1.2547051442911, 5, 2, 0, 0, 0, 76, 34, 0, 0, 0, ?, ?))
```

Someone has -100 assists in a game. Seems unlikely so gate between 0-n where 0 is minimum.