### PR TITLE
fix: escape contents for SEO library

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -18,9 +18,9 @@ class GameController extends Controller
     {
         $images[] = $game->map->thumbnail_url;
 
-        SEOTools::setTitle($game->name);
+        SEOTools::setTitle(e($game->name));
         SEOTools::addImages($images);
-        SEOTools::setDescription($game->description);
+        SEOTools::setDescription(e($game->description));
 
         return view('pages.game', [
             'game' => $game,

--- a/app/Http/Controllers/HcsController.php
+++ b/app/Http/Controllers/HcsController.php
@@ -19,8 +19,8 @@ class HcsController extends Controller
 
     public function championship(Championship $championship, string $bracket = Bracket::WINNERS, int $round = 1): View
     {
-        SEOTools::setTitle($championship->name);
-        SEOTools::setDescription($championship->name.' ('.$championship->region.')');
+        SEOTools::setTitle(e($championship->name));
+        SEOTools::setDescription(e($championship->name.' ('.$championship->region.')'));
 
         return view('pages.championship', [
             'championship' => $championship,

--- a/app/Http/Controllers/LeaderboardController.php
+++ b/app/Http/Controllers/LeaderboardController.php
@@ -26,11 +26,11 @@ class LeaderboardController extends Controller
 
     public function medal(Medal $medal): View
     {
-        SEOTools::setTitle($medal->name.' Leaderboards');
+        SEOTools::setTitle(e($medal->name.' Leaderboards'));
         SEOTools::addImages([
             $medal->image,
         ]);
-        SEOTools::setDescription('Halo Infinite Medal: '.$medal->name.' Leaderboards');
+        SEOTools::setDescription(e('Halo Infinite Medal: '.$medal->name.' Leaderboards'));
 
         /** @var ScheduleTimer $timer */
         $timer = resolve(ScheduleTimerInterface::class);
@@ -45,8 +45,8 @@ class LeaderboardController extends Controller
     {
         $analyticClass = Analytic::getStatFromEnum($key);
 
-        SEOTools::setTitle($analyticClass->title().' Top Ten Leaderboards');
-        SEOTools::setDescription('Top Ten Halo Infinite Leaderboards: '.$analyticClass->title());
+        SEOTools::setTitle(e($analyticClass->title().' Top Ten Leaderboards'));
+        SEOTools::setDescription(e('Top Ten Halo Infinite Leaderboards: '.$analyticClass->title()));
 
         return view('pages.topten-leaderboard', [
             'analyticClass' => $analyticClass,

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -14,8 +14,8 @@ class OverviewController extends Controller
 {
     public function list(string $filterType = OverviewType::MATCHMAKING): View
     {
-        SEOTools::setTitle('Map Overviews');
-        SEOTools::setDescription('Halo Infinite - Leaf Map Overviews');
+        SEOTools::setTitle(e('Map Overviews'));
+        SEOTools::setDescription(e('Halo Infinite - Leaf Map Overviews'));
 
         return view('pages.overviews', [
             'type' => $filterType,
@@ -24,11 +24,11 @@ class OverviewController extends Controller
 
     public function show(Overview $overview, string $tab = OverviewTab::OVERVIEW): View
     {
-        SEOTools::setTitle('Map Overview: '.$overview->name);
+        SEOTools::setTitle(e('Map Overview: '.$overview->name));
         SEOTools::addImages([
             $overview->image,
         ]);
-        SEOTools::setDescription('Halo Infinite - Leaf Map Overview: '.$overview->name);
+        SEOTools::setDescription(e('Halo Infinite - Leaf Map Overview: '.$overview->name));
 
         return view('pages.overview', [
             'overview' => $overview,

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -22,11 +22,11 @@ class PlayerController extends Controller
 {
     public function index(Request $request, Player $player, string $type = PlayerTab::OVERVIEW): View
     {
-        SEOTools::setTitle($player->gamertag.' '.Str::title($type));
+        SEOTools::setTitle(e($player->gamertag.' '.Str::title($type)));
         SEOTools::addImages([
             $player->emblem_url,
         ]);
-        SEOTools::setDescription($player->gamertag.' Halo Infinite '.Str::title($type));
+        SEOTools::setDescription(e($player->gamertag.' Halo Infinite '.Str::title($type)));
 
         return view('pages.player', [
             'player' => $player,

--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -24,8 +24,8 @@ class PlaylistController extends Controller
             abort(Response::HTTP_NOT_FOUND);
         }
 
-        SEOTools::setTitle($playlist->name);
-        SEOTools::setDescription($playlist->title);
+        SEOTools::setTitle(e($playlist->name));
+        SEOTools::setDescription(e($playlist->title));
 
         $playlists = Playlist::query()
             ->where('is_active', true)


### PR DESCRIPTION
I thought my upstream library did this...Apparently not - https://github.com/artesaos/seotools/issues/326