### PR TITLE
fix: ignore new ff playlist (Battle 4 Reach)

### DIFF
--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -301,6 +301,7 @@ class Player extends Model implements HasDotApi, Sitemapable
             config('services.halo.playlists.firefight-composer-normal'),
             config('services.halo.playlists.firefight-composer-heroic'),
             config('services.halo.playlists.firefight-composer-legendary'),
+            config('services.halo.playlists.firefight-battle-for-reach'),
         ];
 
         $firefightIds = Playlist::query()

--- a/app/Support/Analytics/BaseGameStat.php
+++ b/app/Support/Analytics/BaseGameStat.php
@@ -34,6 +34,7 @@ class BaseGameStat
             config('services.halo.playlists.firefight-composer-normal'),
             config('services.halo.playlists.firefight-composer-heroic'),
             config('services.halo.playlists.firefight-composer-legendary'),
+            config('services.halo.playlists.firefight-battle-for-reach'),
         ];
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -83,6 +83,7 @@ return [
             'firefight-composer-normal' => env('HALO_PLAYLISTS_FF_COMPOSER_NORMAL', '1f58f2e2-324d-4770-bca7-e36c63662626'),
             'firefight-composer-heroic' => env('HALO_PLAYLISTS_FF_COMPOSER_HEROIC', '4ec3a07b-edec-4fdd-aa7e-668dc6398ac2'),
             'firefight-composer-legendary' => env('HALO_PLAYLISTS_FF_COMPOSER_LEGENDARY', 'd3c44874-7f46-4f8b-b9a8-92db24cf807e'),
+            'firefight-battle-for-reach' => env('HALO_PLAYLISTS_FF_BATTLE_FOR_REACH', '05a31b26-514b-49ca-856c-3f2cb965a636'),
         ],
         'botfarmer_threshold' => env('HALO_BOTFARMER_THRESHOLD', .50),
     ],


### PR DESCRIPTION
This should knock the top ten (no deaths) back into normal.