### PR TITLE
chore: remove hacky 8.4 workaround

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Composer Dependencies
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist --ignore-platform-reqs
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/deploy.php
+++ b/deploy.php
@@ -10,7 +10,6 @@ set('repository', 'git@github.com:iBotPeaches/LeafApp_Infinite.git');
 set('php_fpm_service', 'php8.4-fpm');
 set('git_ssh_command', 'ssh -o StrictHostKeyChecking=no');
 set('default_timeout', 1800);
-set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader --ignore-platform-reqs');
 
 host('prod')
     ->set('remote_user', 'leaf')


### PR DESCRIPTION
With Laravel Sitemap out - no need for hacky workarounds now.