### PR TITLE
fix: use message + player for ban hash

### DIFF
--- a/app/Models/PlayerBan.php
+++ b/app/Models/PlayerBan.php
@@ -74,7 +74,7 @@ class PlayerBan extends Model implements HasDotApi
         // There is nothing unique about a ban message. So lets make a key of a slugged message with datetime of expiration.
         $message = Arr::get($payload, 'message');
         $endDate = Arr::get($payload, 'end_date');
-        $key = md5(Str::slug($message).$endDate);
+        $key = md5(Str::slug($message).$player->id);
 
         /** @var PlayerBan $playerBan */
         $playerBan = self::query()

--- a/database/migrations/2025_01_11_140745_reprocess_hash_ban_keys.php
+++ b/database/migrations/2025_01_11_140745_reprocess_hash_ban_keys.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\PlayerBan;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        PlayerBan::query()
+            ->with('player')
+            ->whereNotNull('key')
+            ->get()
+            ->each(function (PlayerBan $ban) {
+                $ban->update([
+                    'key' => md5(Str::slug($ban->message).$ban->player_id),
+                ]);
+            });
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
Improperly used end date instead of player for hash key to de-dupe.