### PR TITLE
Add Gamertag search to Navigation Bar

### DIFF
--- a/app/Livewire/AddGamerForm.php
+++ b/app/Livewire/AddGamerForm.php
@@ -30,7 +30,7 @@ class AddGamerForm extends Component
         $this->isNav = $isNav;
     }
 
-    public function updatedGamertag(string $value): void
+    public function updatedGamertag(?string $value): void
     {
         $this->resetValidation('gamertag');
     }

--- a/app/Livewire/AddGamerForm.php
+++ b/app/Livewire/AddGamerForm.php
@@ -15,6 +15,8 @@ class AddGamerForm extends Component
     // @phpstan-ignore-next-line
     public $gamertag;
 
+    public bool $isNav;
+
     protected array $rules = [
         'gamertag' => [
             'required',
@@ -22,6 +24,11 @@ class AddGamerForm extends Component
             'max:32',
         ],
     ];
+
+    public function mount(bool $isNav = false): void
+    {
+        $this->isNav = $isNav;
+    }
 
     public function updatedGamertag(string $value): void
     {

--- a/app/Livewire/AddGamerForm.php
+++ b/app/Livewire/AddGamerForm.php
@@ -23,6 +23,11 @@ class AddGamerForm extends Component
         ],
     ];
 
+    public function updatedGamertag(string $value): void
+    {
+        $this->resetValidation('gamertag');
+    }
+
     public function submit(): ?Redirector
     {
         $this->validate();

--- a/resources/views/livewire/add-gamer-form.blade.php
+++ b/resources/views/livewire/add-gamer-form.blade.php
@@ -1,30 +1,56 @@
 <div>
-    <section class="card">
-        <header class="card-header">
-            <p class="card-header-title">
-                Add Account
-            </p>
-        </header>
-        <form wire:submit="submit" class="card-content">
-            <div class="field has-addons">
-                <div class="control is-expanded has-icons-left @error('gamertag') has-icons-right @enderror">
-                    <input class="input @error('gamertag') is-danger @enderror" type="text" wire:model.live="gamertag" placeholder="Gamertag">
+    @if ($isNav)
+        <form wire:submit="submit" class="m-0">
+            <div class="field m-0">
+                <div
+                    class="control has-icons-left has-icons-right"
+                    wire:loading.class="is-loading"
+                    wire:loading.class.remove="@error('gamertag') is-loading @enderror"
+                >
+                    <input
+                        class="input @error('gamertag') is-danger @enderror"
+                        type="text"
+                        wire:model.live="gamertag"
+                        placeholder="Gamertag"
+                    >
                     <span class="icon is-small is-left">
                         <i class="fab fa-xbox"></i>
                     </span>
                     @error('gamertag')
-                        <span class="icon is-small is-right">
-                            <i class="fas fa-exclamation-triangle"></i>
+                        <span class="icon is-small is-right has-text-danger">
+                            <i class="fas fa-exclamation-triangle" title="The gamertag is invalid"></i>
                         </span>
                     @enderror
                 </div>
-                <div class="control">
-                    <button class="button is-link">Find Me</button>
-                </div>
-                <br />
             </div>
-            <p class="help is-info" wire:loading>Searching Halo Infinite for your account.</p>
-            @error('gamertag')<p class="help is-danger">The gamertag is invalid</p>@enderror
         </form>
-    </section>
+    @else
+        <section class="card">
+            <header class="card-header">
+                    <p class="card-header-title">
+                    Add Account
+                </p>
+            </header>
+            <form wire:submit="submit" class="card-content">
+                <div class="field has-addons">
+                    <div class="control is-expanded has-icons-left @error('gamertag') has-icons-right @enderror">
+                        <input class="input @error('gamertag') is-danger @enderror" type="text" wire:model.live="gamertag" placeholder="Gamertag">
+                        <span class="icon is-small is-left">
+                            <i class="fab fa-xbox"></i>
+                        </span>
+                        @error('gamertag')
+                            <span class="icon is-small is-right">
+                                <i class="fas fa-exclamation-triangle"></i>
+                            </span>
+                        @enderror
+                    </div>
+                    <div class="control">
+                        <button class="button is-link">Find Me</button>
+                    </div>
+                </div>
+                <p class="help is-info" wire:loading>Searching Halo Infinite for your account.</p>
+                @error('gamertag')<p class="help is-danger">The gamertag is invalid</p>@enderror
+            </form>
+        </section>
+    @endif
 </div>

--- a/resources/views/partials/global/navigation.blade.php
+++ b/resources/views/partials/global/navigation.blade.php
@@ -47,7 +47,13 @@
         </div>
 
         <div class="navbar-end">
-            <div class="navbar-item">
+            <div class="navbar-item m-0 py-0">
+                @if (!request()->routeIs('home'))
+                    <div class="navbar-item px-2">
+                        <livewire:add-gamer-form :isNav="true" />
+                    </div>
+                @endif
+
                 <div class="buttons">
                     @guest
                         <a href="{{ route('googleRedirect') }}" class="button is-danger">


### PR DESCRIPTION
## Overview
This PR adds the gamertag search functionality to the navigation bar, allowing users to search for gamertags from any page except the homepage. This addresses user feedback about having to return to the homepage to perform new searches.

## Changes
- Added gamertag search to navbar using existing AddGamerForm Livewire component
- Improved validation UX by resetting validation state when modifying failed entries
- Created conditional rendering for navbar vs homepage search components

### Details
- Added `isNav` property to AddGamerForm Livewire component to control rendering context
- Modified validation behavior to clear error states when user modifies input after a failed validation
- Adjusted component styling for navbar context:
  - Removed section/header elements
  - Removed info messages
  - Added permanent `has-icons-right` class to maintain consistent input width

## Known Issues
- Local tests are currently failing, but appear unrelated to these changes
- Will address test coverage and fixes in a follow-up commit before merge

## Notes
As I'm returning to PHP development after a decade, some implementations might not follow current best practices. I welcome feedback on maintaining project standards and conventions.