### PR TITLE
fix: add 'Classic' gamemode, fallback to category

### DIFF
--- a/app/Support/Gametype/GametypeHelper.php
+++ b/app/Support/Gametype/GametypeHelper.php
@@ -14,8 +14,12 @@ class GametypeHelper
     {
         $name = $gamevariant->name;
 
-        // Some modes are just "Arena", but we can look back at the category to determine the base gametype
-        if ($name === 'Arena' && $gamevariant->category) {
+        $genericModes = [
+            'Arena',
+            'Classic',
+        ];
+
+        if (in_array($name, $genericModes, true) && $gamevariant->category) {
             $name = $gamevariant->category->name ?? $name;
         }
 

--- a/tests/Feature/Console/RefreshOverviewsTest.php
+++ b/tests/Feature/Console/RefreshOverviewsTest.php
@@ -64,6 +64,11 @@ class RefreshOverviewsTest extends TestCase
             ->createOne([
                 'name' => 'Neutral Bomb',
             ]);
+        $classic = Gamevariant::factory()
+            ->for(Category::factory()->set('name', 'Firefight'))
+            ->createOne([
+                'name' => 'Classic',
+            ]);
 
         $map1 = Map::factory()->createOne([
             'name' => 'Absolute',
@@ -142,6 +147,11 @@ class RefreshOverviewsTest extends TestCase
         Game::factory()->createOne([
             'map_id' => $map1->id,
             'gamevariant_id' => $neutralBomb->id,
+        ]);
+
+        Game::factory()->createOne([
+            'map_id' => $map1->id,
+            'gamevariant_id' => $classic->id,
         ]);
 
         // Act


### PR DESCRIPTION
A lot of gametypes suck with names - pure "Arena" or "Classic". For those we can fallback to base gametype to identify.