### PR TITLE
fix: refer to "Cheater" as "Banned"

### DIFF
--- a/resources/views/livewire/banned-player-table.blade.php
+++ b/resources/views/livewire/banned-player-table.blade.php
@@ -33,7 +33,7 @@
                                             </span>
                                     @endif
                                     @if ($player->is_cheater)
-                                        <span class="tag is-danger">Cheater</span>
+                                        <span class="tag is-danger">Banned</span>
                                     @endif
                                     @if ($player->is_botfarmer)
                                         <span class="tag is-info">Farmer</span>

--- a/resources/views/livewire/medals-leaderboard.blade.php
+++ b/resources/views/livewire/medals-leaderboard.blade.php
@@ -58,7 +58,7 @@
                                             </span>
                                         @endif
                                         @if ($result->player?->is_cheater)
-                                            <span class="tag is-danger">Cheater</span>
+                                            <span class="tag is-danger">Banned</span>
                                         @endif
                                         @if ($result->player?->is_botfarmer)
                                             <span class="tag is-info">Farmer</span>

--- a/resources/views/livewire/top-ten-leaderboard.blade.php
+++ b/resources/views/livewire/top-ten-leaderboard.blade.php
@@ -54,7 +54,7 @@ use App\Enums\AnalyticType;
                                                 </span>
                                             @endif
                                             @if ($result->player?->is_cheater)
-                                                <span class="tag is-danger">Cheater</span>
+                                                <span class="tag is-danger">Banned</span>
                                             @endif
                                             @if ($result->player?->is_botfarmer)
                                                 <span class="tag is-info">Farmer</span>

--- a/resources/views/pages/player.blade.php
+++ b/resources/views/pages/player.blade.php
@@ -32,7 +32,7 @@
             @endif
             @if ($player->is_cheater)
                 <div class="notification is-danger mb-2">
-                    <i class="fas fa-exclamation-triangle"></i> Flagged as Cheater
+                    <i class="fas fa-exclamation-triangle"></i> Account is banned
                 </div>
             @endif
             @if ($player->is_botfarmer)

--- a/resources/views/partials/game/team-table.blade.php
+++ b/resources/views/partials/game/team-table.blade.php
@@ -61,7 +61,7 @@ use Illuminate\Support\Str;
                                 @if ($gamePlayer->player->is_bot)
                                     <span class="tag is-dark">BOT</span>
                                 @elseif ($gamePlayer->player->is_cheater)
-                                    <span class="tag is-danger">Cheater</span>
+                                    <span class="tag is-danger">Banned</span>
                                 @else
                                     <p class="image is-32x32">
                                         @include('partials.game.team_emblem_url')

--- a/resources/views/partials/home/recently_updated.blade.php
+++ b/resources/views/partials/home/recently_updated.blade.php
@@ -22,7 +22,7 @@
                         <article class="media">
                             <figure class="media-left">
                                 @if ($player->is_cheater)
-                                    <span class="tag is-danger">Cheater</span>
+                                    <span class="tag is-danger">Banned</span>
                                 @elseif ($player->is_donator)
                                     <span class="tag is-success">Donator</span>
                                 @elseif ($player->is_botfarmer)


### PR DESCRIPTION
Since some bans are chat bans, etc. I'm rebranding this to "Banned"