### PR TITLE
perf: only re-run all seasons weekly on medal stats

### DIFF
--- a/app/Console/Commands/RefreshMedals.php
+++ b/app/Console/Commands/RefreshMedals.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Command\Command as CommandAlias;
 
 class RefreshMedals extends Command
 {
-    protected $signature = 'analytics:medals:refresh';
+    protected $signature = 'analytics:medals:refresh {--all}';
 
     protected $description = 'Refreshes cache table of medal stats.';
 
@@ -31,11 +31,13 @@ class RefreshMedals extends Command
         });
 
         // Seasons
-        $seasons->each(function (Season $season) use ($medals) {
-            $medals->each(function (Medal $medal) use ($season) {
-                ProcessMedalAnalytic::dispatchSync($medal, $season);
+        if ($this->option('all')) {
+            $seasons->each(function (Season $season) use ($medals) {
+                $medals->each(function (Medal $medal) use ($season) {
+                    ProcessMedalAnalytic::dispatchSync($medal, $season);
+                });
             });
-        });
+        }
 
         return CommandAlias::SUCCESS;
     }

--- a/routes/console.php
+++ b/routes/console.php
@@ -29,6 +29,12 @@ Schedule::command(RefreshPlaylistAnalytics::class)
 Schedule::command(RefreshMedals::class)
     ->withoutOverlapping()
     ->dailyAt('3:01')
+    ->skip(fn () => now()->dayOfWeekIso == 3)
+    ->timezone('America/New_York');
+
+Schedule::command(RefreshMedals::class, ['--all'])
+    ->withoutOverlapping()
+    ->weeklyOn(3, '3:01')
     ->timezone('America/New_York');
 
 Schedule::command(RefreshOverviews::class)

--- a/tests/Feature/Console/RefreshMedalsTest.php
+++ b/tests/Feature/Console/RefreshMedalsTest.php
@@ -8,7 +8,7 @@ use App\Jobs\ProcessMedalAnalytic;
 use App\Models\Medal;
 use App\Models\Season;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Bus;
 use Symfony\Component\Console\Command\Command as CommandAlias;
 use Tests\TestCase;
 
@@ -19,7 +19,7 @@ class RefreshMedalsTest extends TestCase
     public function test_valid_dispatch_of_jobs(): void
     {
         // Arrange
-        Queue::fake();
+        Bus::fake();
         Medal::factory()->createOne();
         Season::factory()->createOne();
 
@@ -29,6 +29,22 @@ class RefreshMedalsTest extends TestCase
             ->assertExitCode(CommandAlias::SUCCESS);
 
         // Assert
-        Queue::assertPushed(ProcessMedalAnalytic::class);
+        Bus::assertDispatchedTimes(ProcessMedalAnalytic::class);
+    }
+
+    public function test_valid_dispatch_of_jobs_for_all(): void
+    {
+        // Arrange
+        Bus::fake();
+        Medal::factory()->createOne();
+        Season::factory()->createOne();
+
+        // Act
+        $this
+            ->artisan('analytics:medals:refresh --all')
+            ->assertExitCode(CommandAlias::SUCCESS);
+
+        // Assert
+        Bus::assertDispatchedTimes(ProcessMedalAnalytic::class, 2);
     }
 }


### PR DESCRIPTION
We are running nearly 15 seasons and ALL every single night. It never catches up. This moves the seasons to a weekly check, but keeps the ALL (total) for daily.