### PR TITLE
fix: don't reban users if they have a historic ban

### DIFF
--- a/app/Console/Commands/CheckForBan.php
+++ b/app/Console/Commands/CheckForBan.php
@@ -50,7 +50,7 @@ class CheckForBan extends Command
             'Expires At',
             'Type',
             'Scope',
-        ], $player->bans->map(function (PlayerBan $ban) {
+        ], $player->bans->where('ends_at', '>', now())->map(function (PlayerBan $ban) {
             return [
                 'messsage' => $ban->message,
                 'expires_at' => $ban->ends_at->toIso8601ZuluString(),

--- a/app/Services/DotApi/ApiClient.php
+++ b/app/Services/DotApi/ApiClient.php
@@ -274,7 +274,7 @@ class ApiClient implements InfiniteInterface
             PlayerBan::fromDotApi($ban);
         }
 
-        return $player->bans;
+        return $player->bans->where('ends_at', '>', now());
     }
 
     public function xuid(string $gamertag): ?string

--- a/database/factories/PlayerBanFactory.php
+++ b/database/factories/PlayerBanFactory.php
@@ -24,4 +24,11 @@ class PlayerBanFactory extends Factory
             'scope' => $this->faker->word,
         ];
     }
+
+    public function expired(): self
+    {
+        return $this->state(fn () => [
+            'ends_at' => now()->subDay()->toIso8601ZuluString(),
+        ]);
+    }
 }


### PR DESCRIPTION
A user's ban expired, a "ban check" re-banned them. This fixes that.