### PR TITLE
fix: validate class implements AnalyticInterface before instantiation

### DIFF
--- a/app/Console/Commands/RefreshAnalytics.php
+++ b/app/Console/Commands/RefreshAnalytics.php
@@ -24,6 +24,13 @@ class RefreshAnalytics extends Command
 
         if ($analyticOption) {
             $analytic = 'App\Support\Analytics\Stats\\'.$analyticOption;
+
+            if (! is_a($analytic, AnalyticInterface::class, true)) {
+                $this->error('Invalid analytic class: '.$analyticOption);
+
+                return self::FAILURE;
+            }
+
             /** @var AnalyticInterface $analyticClass */
             $analyticClass = new $analytic;
 
@@ -39,6 +46,10 @@ class RefreshAnalytics extends Command
 
         foreach ($availableAnalytics as $availableAnalytic) {
             $analytic = 'App\Support\Analytics\Stats\\'.Str::before($availableAnalytic, '.php');
+
+            if (! is_a($analytic, AnalyticInterface::class, true)) {
+                continue;
+            }
 
             /** @var AnalyticInterface $analyticClass */
             $analyticClass = new $analytic;

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -33,8 +33,21 @@ class HomeController extends Controller
             ->first();
 
         $availableAnalytics = Storage::disk('stats')->files();
+        if (empty($availableAnalytics)) {
+            return view('pages.home', [
+                'lastUpdated' => $lastUpdated,
+                'medalAnalytic' => $medalAnalytic,
+                'analyticClass' => null,
+                'analytic' => null,
+            ]);
+        }
+
         $randomAnalytic = 'App\Support\Analytics\Stats\\'.
             Str::before($availableAnalytics[array_rand($availableAnalytics)], '.php');
+
+        if (! is_a($randomAnalytic, AnalyticInterface::class, true)) {
+            abort(500);
+        }
 
         /** @var AnalyticInterface $randomAnalyticClass */
         $randomAnalyticClass = new $randomAnalytic;


### PR DESCRIPTION
Prevents arbitrary class instantiation from filesystem contents or user-supplied artisan arguments by verifying the resolved class implements AnalyticInterface before calling new.