### PR TITLE
fix: prevent webhook auth bypass via timing-safe comparison

### DIFF
--- a/app/Http/Requests/IncomingFaceItRequest.php
+++ b/app/Http/Requests/IncomingFaceItRequest.php
@@ -13,7 +13,7 @@ class IncomingFaceItRequest extends FormRequest
         $secret = config('services.faceit.webhook.secret');
         $header = $this->header('X-Cat-Dog');
 
-        if ($secret === null || $header === null) {
+        if ($secret === null || $secret === '' || $header === null) {
             return false;
         }
 

--- a/app/Http/Requests/IncomingFaceItRequest.php
+++ b/app/Http/Requests/IncomingFaceItRequest.php
@@ -10,7 +10,14 @@ class IncomingFaceItRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->header('X-Cat-Dog') === config('services.faceit.webhook.secret');
+        $secret = config('services.faceit.webhook.secret');
+        $header = $this->header('X-Cat-Dog');
+
+        if ($secret === null || $header === null) {
+            return false;
+        }
+
+        return hash_equals($secret, $header);
     }
 
     public function rules(): array

--- a/tests/Feature/Webhooks/IncomingFaceItWebhookTest.php
+++ b/tests/Feature/Webhooks/IncomingFaceItWebhookTest.php
@@ -23,6 +23,13 @@ use Tests\TestCase;
 
 class IncomingFaceItWebhookTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.faceit.webhook.secret' => 'test-webhook-secret']);
+    }
+
     public function test_incoming_face_it_match_completed(): void
     {
         // Arrange & Act
@@ -248,7 +255,7 @@ class IncomingFaceItWebhookTest extends TestCase
 
         $payload = (new MockMatchStatusFinished)->success();
         $headers = [
-            'X-Cat-Dog' => '',
+            'X-Cat-Dog' => 'test-webhook-secret',
         ];
 
         $response = $this->postJson(route('webhooks.faceit'), $payload, $headers);

--- a/tests/Feature/Webhooks/IncomingFaceItWebhookTest.php
+++ b/tests/Feature/Webhooks/IncomingFaceItWebhookTest.php
@@ -218,4 +218,41 @@ class IncomingFaceItWebhookTest extends TestCase
             ],
         ];
     }
+
+    public function test_incoming_face_it_rejects_webhook_with_missing_signature_header(): void
+    {
+        $payload = (new MockMatchStatusFinished)->success();
+
+        $response = $this->postJson(route('webhooks.faceit'), $payload);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_incoming_face_it_rejects_webhook_when_secret_not_configured(): void
+    {
+        config(['services.faceit.webhook.secret' => null]);
+
+        $payload = (new MockMatchStatusFinished)->success();
+        $headers = [
+            'X-Cat-Dog' => 'secret',
+        ];
+
+        $response = $this->postJson(route('webhooks.faceit'), $payload, $headers);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_incoming_face_it_rejects_webhook_with_empty_secret(): void
+    {
+        config(['services.faceit.webhook.secret' => '']);
+
+        $payload = (new MockMatchStatusFinished)->success();
+        $headers = [
+            'X-Cat-Dog' => '',
+        ];
+
+        $response = $this->postJson(route('webhooks.faceit'), $payload, $headers);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
 }


### PR DESCRIPTION
Uses hash_equals() instead of === to prevent timing attacks, and explicitly rejects requests when the webhook secret is not configured.