### PR TITLE
fix: use Carbon copy() to prevent date mutation in matchup query

### DIFF
--- a/app/Jobs/FindMatchesFromMatchup.php
+++ b/app/Jobs/FindMatchesFromMatchup.php
@@ -62,9 +62,9 @@ class FindMatchesFromMatchup implements ShouldQueue
                     $startedAt = $this->matchup->started_at;
                     if ($startedAt) {
                         $query
-                            ->whereDate('occurred_at', $startedAt->subDay())
+                            ->whereDate('occurred_at', $startedAt->copy()->subDay())
                             ->orWhereDate('occurred_at', $startedAt)
-                            ->orWhereDate('occurred_at', $startedAt->addDay());
+                            ->orWhereDate('occurred_at', $startedAt->copy()->addDay());
                     }
                 })
                 ->cursor()

--- a/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
+++ b/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace Tests\Feature\Jobs;
 
 use App\Jobs\FindMatchesFromMatchup;
+use App\Models\Game;
+use App\Models\GamePlayer;
 use App\Models\Matchup;
+use App\Models\MatchupTeam;
+use App\Models\Pivots\MatchupPlayer;
+use App\Models\Player;
+use App\Services\DotApi\InfiniteInterface;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Mockery;
 use Tests\TestCase;
 
 class FindMatchesFromMatchupTest extends TestCase
@@ -29,5 +38,49 @@ class FindMatchesFromMatchupTest extends TestCase
 
         // Assert
         Http::assertNothingSent();
+    }
+
+    public function test_finds_games_happening_the_day_after_matchup_start(): void
+    {
+        // Arrange
+        $this->app->instance(
+            InfiniteInterface::class,
+            Mockery::mock(InfiniteInterface::class)
+                ->shouldReceive('matches')
+                ->once()
+                ->andReturn(new Collection())
+                ->getMock()
+        );
+
+        $startedAt = Carbon::parse('2026-01-15 18:30:00');
+        $matchup = Matchup::factory()->createOne([
+            'started_at' => $startedAt,
+        ]);
+        $player = Player::factory()->createOne();
+        $matchupTeam = MatchupTeam::factory()->createOne([
+            'matchup_id' => $matchup->id,
+        ]);
+        MatchupPlayer::factory()->createOne([
+            'matchup_team_id' => $matchupTeam->id,
+            'player_id' => $player->id,
+        ]);
+
+        $nextDayGame = Game::factory()->createOne([
+            'playlist_id' => null,
+            'occurred_at' => $startedAt->copy()->addDay(),
+        ]);
+        GamePlayer::factory()->createOne([
+            'game_id' => $nextDayGame->id,
+            'player_id' => $player->id,
+        ]);
+
+        // Act
+        FindMatchesFromMatchup::dispatchSync($matchup);
+
+        // Assert
+        $this->assertDatabaseHas('matchup_game', [
+            'matchup_id' => $matchup->id,
+            'game_id' => $nextDayGame->id,
+        ]);
     }
 }

--- a/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
+++ b/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
@@ -13,8 +13,8 @@ use App\Models\Pivots\MatchupPlayer;
 use App\Models\Player;
 use App\Services\DotApi\InfiniteInterface;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Mockery;
@@ -48,7 +48,7 @@ class FindMatchesFromMatchupTest extends TestCase
             Mockery::mock(InfiniteInterface::class)
                 ->shouldReceive('matches')
                 ->once()
-                ->andReturn(new Collection())
+                ->andReturn(new EloquentCollection)
                 ->getMock()
         );
 


### PR DESCRIPTION
The mutable subDay()/addDay() calls shifted the date reference, causing the query to search (day-1, day-1, day) instead of (day-1, day, day+1), silently missing next-day matches.