### PR TITLE
fix: handle null service record on medals page

### DIFF
--- a/app/Livewire/MedalsPage.php
+++ b/app/Livewire/MedalsPage.php
@@ -29,7 +29,7 @@ class MedalsPage extends Component
         $serviceRecord = $this->player->$serviceRecordType()->ofSeason($season)->first();
 
         $medals = Medal::all()->map(function (Medal $medal) use ($serviceRecord) {
-            $medal['count'] = $serviceRecord->medals[$medal->id] ?? 0;
+            $medal['count'] = $serviceRecord?->medals[$medal->id] ?? 0;
 
             return $medal;
         })->sortBy('name');


### PR DESCRIPTION
Uses null-safe operator to prevent crash when a player has no service record for the selected season/mode combination.