### PR TITLE
fix: guard against null division in CSR calculations

### DIFF
--- a/app/Models/Csr.php
+++ b/app/Models/Csr.php
@@ -121,7 +121,7 @@ class Csr extends Model implements HasDotApi
 
     public function getNextRankPercentAttribute(): float
     {
-        if ($this->next_xp_for_level === 0) {
+        if ($this->next_xp_for_level === 0 || $this->current_xp_for_level === null) {
             return 0;
         }
 

--- a/app/Models/Traits/HasCsr.php
+++ b/app/Models/Traits/HasCsr.php
@@ -37,6 +37,10 @@ trait HasCsr
 
     public function getCsrChangeRawAttribute(): int
     {
+        if ($this->post_csr === null || $this->pre_csr === null) {
+            return 0;
+        }
+
         return $this->post_csr - $this->pre_csr;
     }
 

--- a/app/Support/Csr/CsrHelper.php
+++ b/app/Support/Csr/CsrHelper.php
@@ -10,13 +10,21 @@ class CsrHelper
 {
     public static function getCsrFromValue(?int $value, ?int $matchesRemaining, ?int $championRank): Csr
     {
+        $matchesCompleted = $matchesRemaining === null ? 0 : (5 - $matchesRemaining);
+
+        if ($championRank !== null) {
+            return new Csr($championRank, null, 'Champion');
+        }
+
+        if ($value === null) {
+            return new Csr(0, $matchesCompleted, 'Unranked');
+        }
+
         // Since there is 50 CSR per level and 6 levels per class
         $rankClass = $value / 50;
         $subTier = (int) ceil($rankClass + 0.001);
-        $matchesCompleted = $matchesRemaining === null ? 0 : (5 - $matchesRemaining);
 
         return match (true) {
-            $championRank !== null => new Csr($championRank, null, 'Champion'),
             $rankClass > 0 && $rankClass < 6 => new Csr($value, $subTier, 'Bronze'),
             $rankClass >= 6 && $rankClass < 12 => new Csr($value, ($subTier - 6), 'Silver'),
             $rankClass >= 12 && $rankClass < 18 => new Csr($value, ($subTier - 12), 'Gold'),


### PR DESCRIPTION
Adds null checks before arithmetic operations in CsrHelper, Csr model, and HasCsr trait to prevent TypeErrors when CSR values are null (e.g. players in placement matches).