### PR TITLE
chore: migrate to Double (Mockery replacement)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
-        "laravel/pint": "^1.5",
-        "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^8.1",
+        "jasonmccreary/double": "^0.6.1",
         "larastan/larastan": "^3.1",
+        "laravel/pint": "^1.5",
+        "mockery/mockery": "^1.6",
+        "nunomaduro/collision": "^8.1",
         "phpunit/phpunit": "^13.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "830a7719e4607abca7b2849b3188cfe4",
+    "content-hash": "be240ef02a623d43f6559b3986ae585a",
     "packages": [
         {
             "name": "artesaos/seotools",
@@ -8623,6 +8623,57 @@
                 "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
             },
             "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "jasonmccreary/double",
+            "version": "v0.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jasonmccreary/double.git",
+                "reference": "c9d6d75e83ef17ea783ed5430c9f466aac85dadb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jasonmccreary/double/zipball/c9d6d75e83ef17ea783ed5430c9f466aac85dadb",
+                "reference": "c9d6d75e83ef17ea783ed5430c9f466aac85dadb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.29",
+                "phpunit/phpunit": "^11.5.50 || ^12.5.8 || ^13.0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JMac\\Testing\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jason McCreary",
+                    "email": "jason@pureconcepts.net"
+                }
+            ],
+            "description": "A modern PHP double library that puts developer experience first.",
+            "keywords": [
+                "Double",
+                "mock",
+                "spy",
+                "stub",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/jasonmccreary/double/issues",
+                "source": "https://github.com/jasonmccreary/double/tree/v0.6.1"
+            },
+            "time": "2026-08-19T22:33:25+00:00"
         },
         {
             "name": "larastan/larastan",

--- a/tests/Feature/Console/PullOverviewImagesTest.php
+++ b/tests/Feature/Console/PullOverviewImagesTest.php
@@ -9,7 +9,7 @@ use App\Models\Overview;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
+use JMac\Testing\Double;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Mocks\Image\MockImageService;
 use Tests\TestCase;
@@ -24,14 +24,9 @@ class PullOverviewImagesTest extends TestCase
         Http::preventStrayRequests();
         Storage::fake();
 
-        $this->instance(
-            FileUtilInterface::class,
-            Mockery::mock(FileUtilInterface::class, function (Mockery\MockInterface $mock) {
-                $mock
-                    ->shouldReceive('getFileContents')
-                    ->andReturn('example-binary-contents');
-            })
-        );
+        $fileUtil = Double::for(FileUtilInterface::class);
+        $fileUtil->allows('getFileContents')->returns('example-binary-contents');
+        $this->instance(FileUtilInterface::class, $fileUtil);
 
         $mockOptimizedResponse = (new MockImageService)->success();
         $headers = ['Location' => 'domain.com'];

--- a/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
+++ b/tests/Feature/Jobs/FindMatchesFromMatchupTest.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
-use Mockery;
+use JMac\Testing\Double;
 use Tests\TestCase;
 
 class FindMatchesFromMatchupTest extends TestCase
@@ -43,14 +43,9 @@ class FindMatchesFromMatchupTest extends TestCase
     public function test_finds_games_happening_the_day_after_matchup_start(): void
     {
         // Arrange
-        $this->app->instance(
-            InfiniteInterface::class,
-            Mockery::mock(InfiniteInterface::class)
-                ->shouldReceive('matches')
-                ->once()
-                ->andReturn(new EloquentCollection)
-                ->getMock()
-        );
+        $infinite = Double::for(InfiniteInterface::class);
+        $infinite->expects('matches')->returns(new EloquentCollection);
+        $this->app->instance(InfiniteInterface::class, $infinite);
 
         $startedAt = Carbon::parse('2026-01-15 18:30:00');
         $matchup = Matchup::factory()->createOne([

--- a/tests/Feature/Jobs/PullAppearanceTest.php
+++ b/tests/Feature/Jobs/PullAppearanceTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
+use JMac\Testing\Double;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Mocks\Appearance\MockAppearanceService;
 use Tests\Mocks\Image\MockImageService;
@@ -51,14 +51,9 @@ class PullAppearanceTest extends TestCase
         $mockAppearanceResponse = (new MockAppearanceService)->success('gamertag');
         $mockOptimizedResponse = (new MockImageService)->success();
 
-        $this->instance(
-            FileUtilInterface::class,
-            Mockery::mock(FileUtilInterface::class, function (Mockery\MockInterface $mock) {
-                $mock
-                    ->shouldReceive('getFileContents')
-                    ->andReturn('example-binary-contents');
-            })
-        );
+        $fileUtil = Double::for(FileUtilInterface::class);
+        $fileUtil->allows('getFileContents')->returns('example-binary-contents');
+        $this->instance(FileUtilInterface::class, $fileUtil);
 
         $headers = ['Location' => 'domain.com'];
         Http::fakeSequence()

--- a/tests/Feature/Jobs/PullLogoFromMatchupTeamTest.php
+++ b/tests/Feature/Jobs/PullLogoFromMatchupTeamTest.php
@@ -10,7 +10,7 @@ use App\Models\MatchupTeam;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
+use JMac\Testing\Double;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Mocks\Image\MockImageService;
 use Tests\TestCase;
@@ -25,14 +25,9 @@ class PullLogoFromMatchupTeamTest extends TestCase
         Http::preventStrayRequests();
         Storage::fake();
 
-        $this->instance(
-            FileUtilInterface::class,
-            Mockery::mock(FileUtilInterface::class, function (Mockery\MockInterface $mock) {
-                $mock
-                    ->shouldReceive('getFileContents')
-                    ->andReturn('example-binary-contents');
-            })
-        );
+        $fileUtil = Double::for(FileUtilInterface::class);
+        $fileUtil->allows('getFileContents')->returns('example-binary-contents');
+        $this->instance(FileUtilInterface::class, $fileUtil);
 
         $mockOptimizedResponse = (new MockImageService)->success();
         $headers = ['Location' => 'domain.com'];

--- a/tests/Feature/Pages/AuthenticationTest.php
+++ b/tests/Feature/Pages/AuthenticationTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Feature\Pages;
 
 use App\Models\User;
+use JMac\Testing\Double;
+use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\Contracts\Provider;
 use Laravel\Socialite\Facades\Socialite;
-use Mockery;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
@@ -25,12 +27,7 @@ class AuthenticationTest extends TestCase
     public function test_authentication_callback(): void
     {
         // Arrange
-        $abstractUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
-        $abstractUser
-            ->shouldReceive('getId')
-            ->andReturn(rand());
-
-        Socialite::shouldReceive('driver->user')->andReturn($abstractUser);
+        $this->fakeSocialiteUser(rand());
 
         // Act
         $response = $this->get('/auth/google/callback');
@@ -43,12 +40,7 @@ class AuthenticationTest extends TestCase
     {
         // Arrange
         $googleId = rand();
-        $abstractUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
-        $abstractUser
-            ->shouldReceive('getId')
-            ->andReturn($googleId);
-
-        Socialite::shouldReceive('driver->user')->andReturn($abstractUser);
+        $this->fakeSocialiteUser($googleId);
 
         User::factory()->createOne([
             'google_id' => $googleId,
@@ -73,5 +65,19 @@ class AuthenticationTest extends TestCase
 
         // Assert
         $response->assertRedirect();
+    }
+
+    private function fakeSocialiteUser(int $googleId): void
+    {
+        $abstractUser = Double::for(\Laravel\Socialite\Two\User::class);
+        $abstractUser->allows('getId')->returns($googleId);
+
+        $provider = Double::for(Provider::class);
+        $provider->allows('user')->returns($abstractUser);
+
+        $socialite = Double::for(Factory::class);
+        $socialite->allows('driver')->returns($provider);
+
+        Socialite::swap($socialite);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,8 +4,10 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use JMac\Testing\Integrations\PHPUnit\VerifiesDoubles;
 
 abstract class TestCase extends BaseTestCase
 {
     use LazilyRefreshDatabase;
+    use VerifiesDoubles;
 }

--- a/tests/Unit/Support/VersionHelperTest.php
+++ b/tests/Unit/Support/VersionHelperTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\Unit\Support;
 
 use App\Support\System\VersionHelper;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use JMac\Testing\Double;
 use Tests\TestCase;
 
 class VersionHelperTest extends TestCase
@@ -13,10 +15,10 @@ class VersionHelperTest extends TestCase
     public function test_missing_version_file(): void
     {
         // Arrange
-        File::shouldReceive('exists')
-            ->andReturnTrue();
-        File::shouldReceive('get')
-            ->andReturnNull();
+        $filesystem = Double::for(Filesystem::class);
+        $filesystem->allows('exists')->returns(true);
+        $filesystem->allows('get')->returns(null);
+        File::swap($filesystem);
 
         // Act & Assert
         $this->assertNull(VersionHelper::getVersionString());
@@ -25,10 +27,10 @@ class VersionHelperTest extends TestCase
     public function test_valid_version_file(): void
     {
         // Arrange
-        File::shouldReceive('exists')
-            ->andReturnTrue();
-        File::shouldReceive('get')
-            ->andReturn('v3.3.3');
+        $filesystem = Double::for(Filesystem::class);
+        $filesystem->allows('exists')->returns(true);
+        $filesystem->allows('get')->returns('v3.3.3');
+        File::swap($filesystem);
 
         // Act & Assert
         $this->assertEquals('v3.3.3', VersionHelper::getVersionString());


### PR DESCRIPTION
Tries out https://github.com/jasonmccreary/double

## Good
* Little API changes
* Confirmed better error messages

## Bad
* Laravel doesn't natively support it so the `artisan()` tests that under the hood use Mockery are untouchable.
* Laravel native Facades expose test helpers through Mockery as well. So gotta swap
* I can't fully remove Mockery